### PR TITLE
update sdk and event parsing logic

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2744,7 +2744,6 @@ dependencies = [
 [[package]]
 name = "phoenix-types"
 version = "0.1.9"
-source = "git+https://github.com/Ellipsis-Labs/phoenix-types?branch=master#8d8fdcabedcfd857610ce9dd992097a08ca6e081"
 dependencies = [
  "borsh",
  "bytemuck",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2744,6 +2744,7 @@ dependencies = [
 [[package]]
 name = "phoenix-types"
 version = "0.1.9"
+source = "git+https://github.com/Ellipsis-Labs/phoenix-types?branch=master#0952782fe835dd0aec3e2f4f94688582aefef7fc"
 dependencies = [
  "borsh",
  "bytemuck",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,8 @@ anyhow = "1.0.52"
 solana-sdk = "1.10.32"
 borsh = "0.9.3"
 rand = "0.7.3"
-phoenix-types = { git = "https://github.com/Ellipsis-Labs/phoenix-types", branch = "master" }
+# phoenix-types = { git = "https://github.com/Ellipsis-Labs/phoenix-types", branch = "master" }
+phoenix-types = { path = "../../phoenix-types" }
 ellipsis-client = "0.1.7"
 tokio = { version = "1.8.4", features = ["full"] }
 solana-client = "1.10.32"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,8 +20,7 @@ anyhow = "1.0.52"
 solana-sdk = "1.10.32"
 borsh = "0.9.3"
 rand = "0.7.3"
-# phoenix-types = { git = "https://github.com/Ellipsis-Labs/phoenix-types", branch = "master" }
-phoenix-types = { path = "../../phoenix-types" }
+phoenix-types = { git = "https://github.com/Ellipsis-Labs/phoenix-types", branch = "master" }
 ellipsis-client = "0.1.7"
 tokio = { version = "1.8.4", features = ["full"] }
 solana-client = "1.10.32"

--- a/rust/phoenix-sdk-core/src/lib.rs
+++ b/rust/phoenix-sdk-core/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(map_first_last)]
-
 pub mod market_event;
 pub mod orderbook;
 pub mod sdk_client_core;

--- a/rust/phoenix-sdk-core/src/market_event.rs
+++ b/rust/phoenix-sdk-core/src/market_event.rs
@@ -103,4 +103,5 @@ pub enum MarketEventDetails {
     Evict(Evict),
     Reduce(Reduce),
     FillSummary(FillSummary),
+    Fee(u64),
 }

--- a/rust/phoenix-sdk-core/src/sdk_client_core.rs
+++ b/rust/phoenix-sdk-core/src/sdk_client_core.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshDeserialize;
 use phoenix_types::{
     enums::{SelfTradeBehavior, Side},
     events::MarketEvent,

--- a/rust/phoenix-sdk-core/src/sdk_client_core.rs
+++ b/rust/phoenix-sdk-core/src/sdk_client_core.rs
@@ -73,18 +73,6 @@ pub struct MarketMetadata {
     pub num_base_lots_per_base_unit: u64,
 }
 
-#[derive(Debug, Copy, Clone, BorshDeserialize, BorshSerialize)]
-pub enum MarketEventWrapper {
-    Uninitialized,
-    Header,
-    Fill,
-    Place,
-    Reduce,
-    Evict,
-    FillSummary,
-    Fee,
-}
-
 pub struct SDKClientCore {
     pub markets: BTreeMap<Pubkey, MarketMetadata>,
     pub rng: Arc<Mutex<StdRng>>,

--- a/rust/phoenix-sdk/src/lib.rs
+++ b/rust/phoenix-sdk/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(map_first_last)]
-
 pub mod event_poller;
 pub mod market_event_handler;
 pub use phoenix_sdk_core::orderbook;

--- a/rust/phoenix-sdk/src/market_event_handler.rs
+++ b/rust/phoenix-sdk/src/market_event_handler.rs
@@ -31,8 +31,8 @@ pub trait MarketEventHandler<T> {
                 MarketEventDetails::FillSummary(..) => {
                     self.handle_fill_summary(sender, event)?;
                 }
-                _ => {
-                    // Unimplemented event type
+                MarketEventDetails::Fee(..) => {
+                    // Ignore fee events
                 }
             }
         }

--- a/rust/phoenix-sdk/src/market_event_handler.rs
+++ b/rust/phoenix-sdk/src/market_event_handler.rs
@@ -31,6 +31,9 @@ pub trait MarketEventHandler<T> {
                 MarketEventDetails::FillSummary(..) => {
                     self.handle_fill_summary(sender, event)?;
                 }
+                _ => {
+                    // Unimplemented event type
+                }
             }
         }
         Ok(())

--- a/rust/phoenix-sdk/src/sdk_client.rs
+++ b/rust/phoenix-sdk/src/sdk_client.rs
@@ -285,7 +285,7 @@ impl SDKClient {
                 }
             }
         }
-        self.parse_wrapper_events(sig, event_list)
+        self.parse_phoenix_events(sig, event_list)
     }
 
     pub async fn parse_places(&self, signature: &Signature) -> Vec<PhoenixEvent> {


### PR DESCRIPTION
see: https://github.com/Ellipsis-Labs/phoenix/pull/215

Main change here is the updated way to parse events:
![image](https://user-images.githubusercontent.com/61092285/205727426-8692556a-6be1-4bed-85d4-c2a0e3bb6b71.png)
We no longer need the `MarketEventWrapper` type