### PR TITLE
Change float_price_to_ticks to represent raw base unit float price

### DIFF
--- a/rust/phoenix-sdk-core/src/sdk_client_core.rs
+++ b/rust/phoenix-sdk-core/src/sdk_client_core.rs
@@ -206,7 +206,7 @@ impl SDKClientCore {
 
     /// Takes in a price as a floating point number and converts it to a number of ticks (rounded up)
     pub fn float_price_to_ticks_rounded_up(&self, price: f64) -> u64 {
-        ((price * self.quote_multiplier as f64)
+        ((price * self.raw_base_units_per_base_unit as f64 * self.quote_multiplier as f64)
             / self.tick_size_in_quote_atoms_per_base_unit as f64)
             .ceil() as u64
     }

--- a/rust/phoenix-sdk-core/src/sdk_client_core.rs
+++ b/rust/phoenix-sdk-core/src/sdk_client_core.rs
@@ -200,7 +200,7 @@ impl SDKClientCore {
 
     /// Takes in a price as a floating point number and converts it to a number of ticks (rounded down)
     pub fn float_price_to_ticks(&self, price: f64) -> u64 {
-        ((price * self.quote_multiplier as f64)
+        ((price * self.raw_base_units_per_base_unit as f64 * self.quote_multiplier as f64)
             / self.tick_size_in_quote_atoms_per_base_unit as f64) as u64
     }
 


### PR DESCRIPTION
The method `float_price_to_ticks` was not accounting for `raw_base_units_per_base_unit`, which resulted in the SDK user needing to input a price per `BaseUnit` instead of a price per raw base unit (whole token, as humanly understood). We don't want the SDK users to have to think about our unit system, so the calculation method should include the conversion.

This PR changes the `float_price_to_ticks` method to account for `raw_base_units_per_base_unit` in its calculation.