### PR TITLE
Update SDK to use autogenerate code

### DIFF
--- a/typescript/phoenix-sdk/src/instructions/CancelAllOrders.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelAllOrders.ts
@@ -5,9 +5,9 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as splToken from "@solana/spl-token";
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
+import * as splToken from '@solana/spl-token'
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
 
 /**
  * @category Instructions
@@ -15,15 +15,15 @@ import * as web3 from "@solana/web3.js";
  * @category generated
  */
 export const CancelAllOrdersStruct = new beet.BeetArgsStruct<{
-  instructionDiscriminator: number;
-}>([["instructionDiscriminator", beet.u8]], "CancelAllOrdersInstructionArgs");
+  instructionDiscriminator: number
+}>([['instructionDiscriminator', beet.u8]], 'CancelAllOrdersInstructionArgs')
 /**
  * Accounts required by the _CancelAllOrders_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
  * @property [_writable_] baseVault Base vault PDA, seeds are [b'vault', market_address, base_mint_address]
@@ -33,18 +33,18 @@ export const CancelAllOrdersStruct = new beet.BeetArgsStruct<{
  * @category generated
  */
 export type CancelAllOrdersInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  baseAccount: web3.PublicKey;
-  quoteAccount: web3.PublicKey;
-  baseVault: web3.PublicKey;
-  quoteVault: web3.PublicKey;
-  tokenProgram?: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  baseAccount: web3.PublicKey
+  quoteAccount: web3.PublicKey
+  baseVault: web3.PublicKey
+  quoteVault: web3.PublicKey
+  tokenProgram?: web3.PublicKey
+}
 
-export const cancelAllOrdersInstructionDiscriminator = 6;
+export const cancelAllOrdersInstructionDiscriminator = 6
 
 /**
  * Creates a _CancelAllOrders_ instruction.
@@ -56,11 +56,11 @@ export const cancelAllOrdersInstructionDiscriminator = 6;
  */
 export function createCancelAllOrdersInstruction(
   accounts: CancelAllOrdersInstructionAccounts,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = CancelAllOrdersStruct.serialize({
     instructionDiscriminator: cancelAllOrdersInstructionDiscriminator,
-  });
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -79,7 +79,7 @@ export function createCancelAllOrdersInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -107,12 +107,12 @@ export function createCancelAllOrdersInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/CancelAllOrdersWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelAllOrdersWithFreeFunds.ts
@@ -25,7 +25,7 @@ export const CancelAllOrdersWithFreeFundsStruct = new beet.BeetArgsStruct<{
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @category Instructions
  * @category CancelAllOrdersWithFreeFunds
  * @category generated
@@ -73,7 +73,7 @@ export function createCancelAllOrdersWithFreeFundsInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
   ]

--- a/typescript/phoenix-sdk/src/instructions/CancelMultipleOrdersById.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelMultipleOrdersById.ts
@@ -8,24 +8,16 @@
 import * as splToken from "@solana/spl-token";
 import * as beet from "@metaplex-foundation/beet";
 import * as web3 from "@solana/web3.js";
-import {
-  CancelMultipleOrdersByIdParams,
-  cancelMultipleOrdersByIdParamsBeet,
-} from "../types/CancelMultipleOrdersByIdParams";
 
 /**
  * @category Instructions
  * @category CancelMultipleOrdersById
  * @category generated
  */
-export const CancelMultipleOrdersByIdStruct = new beet.FixableBeetArgsStruct<{
+export const CancelMultipleOrdersByIdStruct = new beet.BeetArgsStruct<{
   instructionDiscriminator: number;
-  params: CancelMultipleOrdersByIdParams;
 }>(
-  [
-    ["instructionDiscriminator", beet.u8],
-    ["params", cancelMultipleOrdersByIdParamsBeet],
-  ],
+  [["instructionDiscriminator", beet.u8]],
   "CancelMultipleOrdersByIdInstructionArgs"
 );
 /**
@@ -34,7 +26,7 @@ export const CancelMultipleOrdersByIdStruct = new beet.FixableBeetArgsStruct<{
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
  * @property [_writable_] baseVault Base vault PDA, seeds are [b'vault', market_address, base_mint_address]
@@ -67,12 +59,10 @@ export const cancelMultipleOrdersByIdInstructionDiscriminator = 10;
  */
 export function createCancelMultipleOrdersByIdInstruction(
   accounts: CancelMultipleOrdersByIdInstructionAccounts,
-  params: CancelMultipleOrdersByIdParams,
   programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
 ) {
   const [data] = CancelMultipleOrdersByIdStruct.serialize({
     instructionDiscriminator: cancelMultipleOrdersByIdInstructionDiscriminator,
-    params,
   });
   const keys: web3.AccountMeta[] = [
     {
@@ -92,7 +82,7 @@ export function createCancelMultipleOrdersByIdInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {

--- a/typescript/phoenix-sdk/src/instructions/CancelMultipleOrdersByIdWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelMultipleOrdersByIdWithFreeFunds.ts
@@ -5,12 +5,8 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
-import {
-  CancelMultipleOrdersByIdParams,
-  cancelMultipleOrdersByIdParamsBeet,
-} from "../types/CancelMultipleOrdersByIdParams";
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
 
 /**
  * @category Instructions
@@ -18,35 +14,29 @@ import {
  * @category generated
  */
 export const CancelMultipleOrdersByIdWithFreeFundsStruct =
-  new beet.FixableBeetArgsStruct<{
-    instructionDiscriminator: number;
-    params: CancelMultipleOrdersByIdParams;
-  }>(
-    [
-      ["instructionDiscriminator", beet.u8],
-      ["params", cancelMultipleOrdersByIdParamsBeet],
-    ],
-    "CancelMultipleOrdersByIdWithFreeFundsInstructionArgs"
-  );
+  new beet.BeetArgsStruct<{ instructionDiscriminator: number }>(
+    [['instructionDiscriminator', beet.u8]],
+    'CancelMultipleOrdersByIdWithFreeFundsInstructionArgs'
+  )
 /**
  * Accounts required by the _CancelMultipleOrdersByIdWithFreeFunds_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @category Instructions
  * @category CancelMultipleOrdersByIdWithFreeFunds
  * @category generated
  */
 export type CancelMultipleOrdersByIdWithFreeFundsInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+}
 
-export const cancelMultipleOrdersByIdWithFreeFundsInstructionDiscriminator = 11;
+export const cancelMultipleOrdersByIdWithFreeFundsInstructionDiscriminator = 11
 
 /**
  * Creates a _CancelMultipleOrdersByIdWithFreeFunds_ instruction.
@@ -58,14 +48,12 @@ export const cancelMultipleOrdersByIdWithFreeFundsInstructionDiscriminator = 11;
  */
 export function createCancelMultipleOrdersByIdWithFreeFundsInstruction(
   accounts: CancelMultipleOrdersByIdWithFreeFundsInstructionAccounts,
-  params: CancelMultipleOrdersByIdParams,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = CancelMultipleOrdersByIdWithFreeFundsStruct.serialize({
     instructionDiscriminator:
       cancelMultipleOrdersByIdWithFreeFundsInstructionDiscriminator,
-    params,
-  });
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -84,15 +72,15 @@ export function createCancelMultipleOrdersByIdWithFreeFundsInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/CancelUpTo.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelUpTo.ts
@@ -5,35 +5,45 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as splToken from "@solana/spl-token";
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
+import * as splToken from '@solana/spl-token'
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
 import {
   CancelUpToParams,
   cancelUpToParamsBeet,
-} from "../types/CancelUpToParams";
+} from '../types/CancelUpToParams'
+
 /**
  * @category Instructions
  * @category CancelUpTo
  * @category generated
  */
-export const CancelUpToStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-  params: CancelUpToParams;
-}>(
+export type CancelUpToInstructionArgs = {
+  params: CancelUpToParams
+}
+/**
+ * @category Instructions
+ * @category CancelUpTo
+ * @category generated
+ */
+export const CancelUpToStruct = new beet.FixableBeetArgsStruct<
+  CancelUpToInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
   [
-    ["instructionDiscriminator", beet.u8],
-    ["params", cancelUpToParamsBeet],
+    ['instructionDiscriminator', beet.u8],
+    ['params', cancelUpToParamsBeet],
   ],
-  "CancelUpToInstructionArgs"
-);
+  'CancelUpToInstructionArgs'
+)
 /**
  * Accounts required by the _CancelUpTo_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
  * @property [_writable_] baseVault Base vault PDA, seeds are [b'vault', market_address, base_mint_address]
@@ -43,36 +53,38 @@ export const CancelUpToStruct = new beet.FixableBeetArgsStruct<{
  * @category generated
  */
 export type CancelUpToInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  baseAccount: web3.PublicKey;
-  quoteAccount: web3.PublicKey;
-  baseVault: web3.PublicKey;
-  quoteVault: web3.PublicKey;
-  tokenProgram?: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  baseAccount: web3.PublicKey
+  quoteAccount: web3.PublicKey
+  baseVault: web3.PublicKey
+  quoteVault: web3.PublicKey
+  tokenProgram?: web3.PublicKey
+}
 
-export const cancelUpToInstructionDiscriminator = 8;
+export const cancelUpToInstructionDiscriminator = 8
 
 /**
  * Creates a _CancelUpTo_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category CancelUpTo
  * @category generated
  */
 export function createCancelUpToInstruction(
   accounts: CancelUpToInstructionAccounts,
-  params: CancelUpToParams,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: CancelUpToInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = CancelUpToStruct.serialize({
     instructionDiscriminator: cancelUpToInstructionDiscriminator,
-    params,
-  });
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -91,7 +103,7 @@ export function createCancelUpToInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -119,12 +131,12 @@ export function createCancelUpToInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/CancelUpToWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelUpToWithFreeFunds.ts
@@ -5,65 +5,76 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
 import {
   CancelUpToParams,
   cancelUpToParamsBeet,
-} from "../types/CancelUpToParams";
+} from '../types/CancelUpToParams'
 
 /**
  * @category Instructions
  * @category CancelUpToWithFreeFunds
  * @category generated
  */
-export const CancelUpToWithFreeFundsStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-  params: CancelUpToParams;
-}>(
+export type CancelUpToWithFreeFundsInstructionArgs = {
+  params: CancelUpToParams
+}
+/**
+ * @category Instructions
+ * @category CancelUpToWithFreeFunds
+ * @category generated
+ */
+export const CancelUpToWithFreeFundsStruct = new beet.FixableBeetArgsStruct<
+  CancelUpToWithFreeFundsInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
   [
-    ["instructionDiscriminator", beet.u8],
-    ["params", cancelUpToParamsBeet],
+    ['instructionDiscriminator', beet.u8],
+    ['params', cancelUpToParamsBeet],
   ],
-  "CancelUpToWithFreeFundsInstructionArgs"
-);
+  'CancelUpToWithFreeFundsInstructionArgs'
+)
 /**
  * Accounts required by the _CancelUpToWithFreeFunds_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @category Instructions
  * @category CancelUpToWithFreeFunds
  * @category generated
  */
 export type CancelUpToWithFreeFundsInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+}
 
-export const cancelUpToWithFreeFundsInstructionDiscriminator = 9;
+export const cancelUpToWithFreeFundsInstructionDiscriminator = 9
 
 /**
  * Creates a _CancelUpToWithFreeFunds_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category CancelUpToWithFreeFunds
  * @category generated
  */
 export function createCancelUpToWithFreeFundsInstruction(
   accounts: CancelUpToWithFreeFundsInstructionAccounts,
-  params: CancelUpToParams,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: CancelUpToWithFreeFundsInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = CancelUpToWithFreeFundsStruct.serialize({
     instructionDiscriminator: cancelUpToWithFreeFundsInstructionDiscriminator,
-    params,
-  });
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -82,15 +93,15 @@ export function createCancelUpToWithFreeFundsInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/DepositFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/DepositFunds.ts
@@ -5,33 +5,42 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as splToken from "@solana/spl-token";
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
-import { DepositParams, depositParamsBeet } from "../types/DepositParams";
+import * as splToken from '@solana/spl-token'
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
+import { DepositParams, depositParamsBeet } from '../types/DepositParams'
 
 /**
  * @category Instructions
  * @category DepositFunds
  * @category generated
  */
-export const DepositFundsStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-  params: DepositParams;
-}>(
+export type DepositFundsInstructionArgs = {
+  depositFundsParams: DepositParams
+}
+/**
+ * @category Instructions
+ * @category DepositFunds
+ * @category generated
+ */
+export const DepositFundsStruct = new beet.BeetArgsStruct<
+  DepositFundsInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
   [
-    ["instructionDiscriminator", beet.u8],
-    ["params", depositParamsBeet],
+    ['instructionDiscriminator', beet.u8],
+    ['depositFundsParams', depositParamsBeet],
   ],
-  "DepositFundsInstructionArgs"
-);
+  'DepositFundsInstructionArgs'
+)
 /**
  * Accounts required by the _DepositFunds_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [] seat
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
@@ -42,37 +51,39 @@ export const DepositFundsStruct = new beet.FixableBeetArgsStruct<{
  * @category generated
  */
 export type DepositFundsInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  seat: web3.PublicKey;
-  baseAccount: web3.PublicKey;
-  quoteAccount: web3.PublicKey;
-  baseVault: web3.PublicKey;
-  quoteVault: web3.PublicKey;
-  tokenProgram?: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  seat: web3.PublicKey
+  baseAccount: web3.PublicKey
+  quoteAccount: web3.PublicKey
+  baseVault: web3.PublicKey
+  quoteVault: web3.PublicKey
+  tokenProgram?: web3.PublicKey
+}
 
-export const depositFundsInstructionDiscriminator = 13;
+export const depositFundsInstructionDiscriminator = 13
 
 /**
  * Creates a _DepositFunds_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category DepositFunds
  * @category generated
  */
 export function createDepositFundsInstruction(
   accounts: DepositFundsInstructionAccounts,
-  params: DepositParams,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: DepositFundsInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = DepositFundsStruct.serialize({
     instructionDiscriminator: depositFundsInstructionDiscriminator,
-    params,
-  });
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -91,7 +102,7 @@ export function createDepositFundsInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -124,12 +135,12 @@ export function createDepositFundsInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/PlaceLimitOrder.ts
+++ b/typescript/phoenix-sdk/src/instructions/PlaceLimitOrder.ts
@@ -5,26 +5,42 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as splToken from "@solana/spl-token";
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
-import { OrderPacket, orderPacketBeet } from "../types/OrderPacket";
+import * as splToken from '@solana/spl-token'
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
+import { OrderPacket, orderPacketBeet } from '../types/OrderPacket'
 
 /**
  * @category Instructions
  * @category PlaceLimitOrder
  * @category generated
  */
-export const PlaceLimitOrderStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-}>([["instructionDiscriminator", beet.u8]], "PlaceLimitOrderInstructionArgs");
+export type PlaceLimitOrderInstructionArgs = {
+  orderPacket: OrderPacket
+}
+/**
+ * @category Instructions
+ * @category PlaceLimitOrder
+ * @category generated
+ */
+export const PlaceLimitOrderStruct = new beet.FixableBeetArgsStruct<
+  PlaceLimitOrderInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
+  [
+    ['instructionDiscriminator', beet.u8],
+    ['orderPacket', orderPacketBeet],
+  ],
+  'PlaceLimitOrderInstructionArgs'
+)
 /**
  * Accounts required by the _PlaceLimitOrder_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [] seat
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
@@ -35,41 +51,39 @@ export const PlaceLimitOrderStruct = new beet.FixableBeetArgsStruct<{
  * @category generated
  */
 export type PlaceLimitOrderInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  seat: web3.PublicKey;
-  baseAccount: web3.PublicKey;
-  quoteAccount: web3.PublicKey;
-  baseVault: web3.PublicKey;
-  quoteVault: web3.PublicKey;
-  tokenProgram?: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  seat: web3.PublicKey
+  baseAccount: web3.PublicKey
+  quoteAccount: web3.PublicKey
+  baseVault: web3.PublicKey
+  quoteVault: web3.PublicKey
+  tokenProgram?: web3.PublicKey
+}
 
-export const placeLimitOrderInstructionDiscriminator = 2;
+export const placeLimitOrderInstructionDiscriminator = 2
 
 /**
  * Creates a _PlaceLimitOrder_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category PlaceLimitOrder
  * @category generated
  */
 export function createPlaceLimitOrderInstruction(
   accounts: PlaceLimitOrderInstructionAccounts,
-  orderPacket: Partial<OrderPacket>,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: PlaceLimitOrderInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
-  const [ixEnum] = PlaceLimitOrderStruct.serialize({
+  const [data] = PlaceLimitOrderStruct.serialize({
     instructionDiscriminator: placeLimitOrderInstructionDiscriminator,
-  });
-
-  const paramData = orderPacketBeet.toFixedFromValue(orderPacket);
-  const data = Buffer.alloc(ixEnum.length + paramData.byteSize, ixEnum);
-  paramData.write(data, ixEnum.length, orderPacket);
-
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -88,7 +102,7 @@ export function createPlaceLimitOrderInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -121,12 +135,12 @@ export function createPlaceLimitOrderInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/PlaceLimitOrderWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/PlaceLimitOrderWithFreeFunds.ts
@@ -5,66 +5,77 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
-import { OrderPacket, orderPacketBeet } from "../types/OrderPacket";
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
+import { OrderPacket, orderPacketBeet } from '../types/OrderPacket'
 
+/**
+ * @category Instructions
+ * @category PlaceLimitOrderWithFreeFunds
+ * @category generated
+ */
+export type PlaceLimitOrderWithFreeFundsInstructionArgs = {
+  orderPacket: OrderPacket
+}
 /**
  * @category Instructions
  * @category PlaceLimitOrderWithFreeFunds
  * @category generated
  */
 export const PlaceLimitOrderWithFreeFundsStruct =
-  new beet.FixableBeetArgsStruct<{
-    instructionDiscriminator: number;
-  }>(
-    [["instructionDiscriminator", beet.u8]],
-    "PlaceLimitOrderWithFreeFundsInstructionArgs"
-  );
+  new beet.FixableBeetArgsStruct<
+    PlaceLimitOrderWithFreeFundsInstructionArgs & {
+      instructionDiscriminator: number
+    }
+  >(
+    [
+      ['instructionDiscriminator', beet.u8],
+      ['orderPacket', orderPacketBeet],
+    ],
+    'PlaceLimitOrderWithFreeFundsInstructionArgs'
+  )
 /**
  * Accounts required by the _PlaceLimitOrderWithFreeFunds_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [] seat
  * @category Instructions
  * @category PlaceLimitOrderWithFreeFunds
  * @category generated
  */
 export type PlaceLimitOrderWithFreeFundsInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  seat: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  seat: web3.PublicKey
+}
 
-export const placeLimitOrderWithFreeFundsInstructionDiscriminator = 3;
+export const placeLimitOrderWithFreeFundsInstructionDiscriminator = 3
 
 /**
  * Creates a _PlaceLimitOrderWithFreeFunds_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category PlaceLimitOrderWithFreeFunds
  * @category generated
  */
 export function createPlaceLimitOrderWithFreeFundsInstruction(
   accounts: PlaceLimitOrderWithFreeFundsInstructionAccounts,
-  orderPacket: Partial<OrderPacket>,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: PlaceLimitOrderWithFreeFundsInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
-  const [ixEnum] = PlaceLimitOrderWithFreeFundsStruct.serialize({
+  const [data] = PlaceLimitOrderWithFreeFundsStruct.serialize({
     instructionDiscriminator:
       placeLimitOrderWithFreeFundsInstructionDiscriminator,
-  });
-
-  const paramData = orderPacketBeet.toFixedFromValue(orderPacket);
-  const data = Buffer.alloc(ixEnum.length + paramData.byteSize, ixEnum);
-  paramData.write(data, ixEnum.length, orderPacket);
-
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -83,7 +94,7 @@ export function createPlaceLimitOrderWithFreeFundsInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -91,12 +102,12 @@ export function createPlaceLimitOrderWithFreeFundsInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/PlaceMultiplePostOnlyOrders.ts
+++ b/typescript/phoenix-sdk/src/instructions/PlaceMultiplePostOnlyOrders.ts
@@ -5,37 +5,45 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as splToken from "@solana/spl-token";
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
+import * as splToken from '@solana/spl-token'
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
 import {
   MultipleOrderPacket,
   multipleOrderPacketBeet,
-} from "../types/MultipleOrderPacket";
+} from '../types/MultipleOrderPacket'
 
 /**
  * @category Instructions
  * @category PlaceMultiplePostOnlyOrders
  * @category generated
  */
-export const PlaceMultiplePostOnlyOrdersStruct =
-  new beet.FixableBeetArgsStruct<{
-    instructionDiscriminator: number;
-    orders: MultipleOrderPacket;
-  }>(
-    [
-      ["instructionDiscriminator", beet.u8],
-      ["orders", multipleOrderPacketBeet],
-    ],
-    "PlaceMultiplePostOnlyOrdersInstructionArgs"
-  );
+export type PlaceMultiplePostOnlyOrdersInstructionArgs = {
+  multipleOrderPacket: MultipleOrderPacket
+}
+/**
+ * @category Instructions
+ * @category PlaceMultiplePostOnlyOrders
+ * @category generated
+ */
+export const PlaceMultiplePostOnlyOrdersStruct = new beet.FixableBeetArgsStruct<
+  PlaceMultiplePostOnlyOrdersInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
+  [
+    ['instructionDiscriminator', beet.u8],
+    ['multipleOrderPacket', multipleOrderPacketBeet],
+  ],
+  'PlaceMultiplePostOnlyOrdersInstructionArgs'
+)
 /**
  * Accounts required by the _PlaceMultiplePostOnlyOrders_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [] seat
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
@@ -46,38 +54,40 @@ export const PlaceMultiplePostOnlyOrdersStruct =
  * @category generated
  */
 export type PlaceMultiplePostOnlyOrdersInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  seat: web3.PublicKey;
-  baseAccount: web3.PublicKey;
-  quoteAccount: web3.PublicKey;
-  baseVault: web3.PublicKey;
-  quoteVault: web3.PublicKey;
-  tokenProgram?: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  seat: web3.PublicKey
+  baseAccount: web3.PublicKey
+  quoteAccount: web3.PublicKey
+  baseVault: web3.PublicKey
+  quoteVault: web3.PublicKey
+  tokenProgram?: web3.PublicKey
+}
 
-export const placeMultiplePostOnlyOrdersInstructionDiscriminator = 16;
+export const placeMultiplePostOnlyOrdersInstructionDiscriminator = 16
 
 /**
  * Creates a _PlaceMultiplePostOnlyOrders_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category PlaceMultiplePostOnlyOrders
  * @category generated
  */
 export function createPlaceMultiplePostOnlyOrdersInstruction(
   accounts: PlaceMultiplePostOnlyOrdersInstructionAccounts,
-  orders: MultipleOrderPacket,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: PlaceMultiplePostOnlyOrdersInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = PlaceMultiplePostOnlyOrdersStruct.serialize({
     instructionDiscriminator:
       placeMultiplePostOnlyOrdersInstructionDiscriminator,
-    orders,
-  });
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -96,7 +106,7 @@ export function createPlaceMultiplePostOnlyOrdersInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -129,12 +139,12 @@ export function createPlaceMultiplePostOnlyOrdersInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/PlaceMultiplePostOnlyOrdersWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/PlaceMultiplePostOnlyOrdersWithFreeFunds.ts
@@ -5,69 +5,80 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
 import {
   MultipleOrderPacket,
   multipleOrderPacketBeet,
-} from "../types/MultipleOrderPacket";
+} from '../types/MultipleOrderPacket'
 
+/**
+ * @category Instructions
+ * @category PlaceMultiplePostOnlyOrdersWithFreeFunds
+ * @category generated
+ */
+export type PlaceMultiplePostOnlyOrdersWithFreeFundsInstructionArgs = {
+  multipleOrderPacket: MultipleOrderPacket
+}
 /**
  * @category Instructions
  * @category PlaceMultiplePostOnlyOrdersWithFreeFunds
  * @category generated
  */
 export const PlaceMultiplePostOnlyOrdersWithFreeFundsStruct =
-  new beet.FixableBeetArgsStruct<{
-    instructionDiscriminator: number;
-    orders: MultipleOrderPacket;
-  }>(
+  new beet.FixableBeetArgsStruct<
+    PlaceMultiplePostOnlyOrdersWithFreeFundsInstructionArgs & {
+      instructionDiscriminator: number
+    }
+  >(
     [
-      ["instructionDiscriminator", beet.u8],
-      ["orders", multipleOrderPacketBeet],
+      ['instructionDiscriminator', beet.u8],
+      ['multipleOrderPacket', multipleOrderPacketBeet],
     ],
-    "PlaceMultiplePostOnlyOrdersWithFreeFundsInstructionArgs"
-  );
+    'PlaceMultiplePostOnlyOrdersWithFreeFundsInstructionArgs'
+  )
 /**
  * Accounts required by the _PlaceMultiplePostOnlyOrdersWithFreeFunds_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [] seat
  * @category Instructions
  * @category PlaceMultiplePostOnlyOrdersWithFreeFunds
  * @category generated
  */
 export type PlaceMultiplePostOnlyOrdersWithFreeFundsInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  seat: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  seat: web3.PublicKey
+}
 
-export const placeMultiplePostOnlyOrdersWithFreeFundsInstructionDiscriminator = 17;
+export const placeMultiplePostOnlyOrdersWithFreeFundsInstructionDiscriminator = 17
 
 /**
  * Creates a _PlaceMultiplePostOnlyOrdersWithFreeFunds_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category PlaceMultiplePostOnlyOrdersWithFreeFunds
  * @category generated
  */
 export function createPlaceMultiplePostOnlyOrdersWithFreeFundsInstruction(
   accounts: PlaceMultiplePostOnlyOrdersWithFreeFundsInstructionAccounts,
-  orders: MultipleOrderPacket,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: PlaceMultiplePostOnlyOrdersWithFreeFundsInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = PlaceMultiplePostOnlyOrdersWithFreeFundsStruct.serialize({
     instructionDiscriminator:
       placeMultiplePostOnlyOrdersWithFreeFundsInstructionDiscriminator,
-    orders,
-  });
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -86,7 +97,7 @@ export function createPlaceMultiplePostOnlyOrdersWithFreeFundsInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -94,12 +105,12 @@ export function createPlaceMultiplePostOnlyOrdersWithFreeFundsInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/ReduceOrder.ts
+++ b/typescript/phoenix-sdk/src/instructions/ReduceOrder.ts
@@ -5,36 +5,45 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as splToken from "@solana/spl-token";
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
+import * as splToken from '@solana/spl-token'
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
 import {
-  CancelOrderParams,
-  cancelOrderParamsBeet,
-} from "../types/CancelOrderParams";
+  ReduceOrderParams,
+  reduceOrderParamsBeet,
+} from '../types/ReduceOrderParams'
 
 /**
  * @category Instructions
  * @category ReduceOrder
  * @category generated
  */
-export const ReduceOrderStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-  params: CancelOrderParams;
-}>(
+export type ReduceOrderInstructionArgs = {
+  params: ReduceOrderParams
+}
+/**
+ * @category Instructions
+ * @category ReduceOrder
+ * @category generated
+ */
+export const ReduceOrderStruct = new beet.BeetArgsStruct<
+  ReduceOrderInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
   [
-    ["instructionDiscriminator", beet.u8],
-    ["params", cancelOrderParamsBeet],
+    ['instructionDiscriminator', beet.u8],
+    ['params', reduceOrderParamsBeet],
   ],
-  "ReduceOrderInstructionArgs"
-);
+  'ReduceOrderInstructionArgs'
+)
 /**
  * Accounts required by the _ReduceOrder_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
  * @property [_writable_] baseVault Base vault PDA, seeds are [b'vault', market_address, base_mint_address]
@@ -44,36 +53,38 @@ export const ReduceOrderStruct = new beet.FixableBeetArgsStruct<{
  * @category generated
  */
 export type ReduceOrderInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  baseAccount: web3.PublicKey;
-  quoteAccount: web3.PublicKey;
-  baseVault: web3.PublicKey;
-  quoteVault: web3.PublicKey;
-  tokenProgram?: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  baseAccount: web3.PublicKey
+  quoteAccount: web3.PublicKey
+  baseVault: web3.PublicKey
+  quoteVault: web3.PublicKey
+  tokenProgram?: web3.PublicKey
+}
 
-export const reduceOrderInstructionDiscriminator = 4;
+export const reduceOrderInstructionDiscriminator = 4
 
 /**
  * Creates a _ReduceOrder_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category ReduceOrder
  * @category generated
  */
 export function createReduceOrderInstruction(
   accounts: ReduceOrderInstructionAccounts,
-  params: CancelOrderParams,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: ReduceOrderInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = ReduceOrderStruct.serialize({
     instructionDiscriminator: reduceOrderInstructionDiscriminator,
-    params,
-  });
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -92,7 +103,7 @@ export function createReduceOrderInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -120,12 +131,12 @@ export function createReduceOrderInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/ReduceOrderWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/ReduceOrderWithFreeFunds.ts
@@ -5,28 +5,37 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
 import {
-  CancelOrderParams,
-  cancelOrderParamsBeet,
-} from "../types/CancelOrderParams";
+  ReduceOrderParams,
+  reduceOrderParamsBeet,
+} from '../types/ReduceOrderParams'
 
 /**
  * @category Instructions
  * @category ReduceOrderWithFreeFunds
  * @category generated
  */
-export const ReduceOrderWithFreeFundsStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-  params: CancelOrderParams;
-}>(
+export type ReduceOrderWithFreeFundsInstructionArgs = {
+  params: ReduceOrderParams
+}
+/**
+ * @category Instructions
+ * @category ReduceOrderWithFreeFunds
+ * @category generated
+ */
+export const ReduceOrderWithFreeFundsStruct = new beet.BeetArgsStruct<
+  ReduceOrderWithFreeFundsInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
   [
-    ["instructionDiscriminator", beet.u8],
-    ["params", cancelOrderParamsBeet],
+    ['instructionDiscriminator', beet.u8],
+    ['params', reduceOrderParamsBeet],
   ],
-  "ReduceOrderWithFreeFundsInstructionArgs"
-);
+  'ReduceOrderWithFreeFundsInstructionArgs'
+)
 /**
  * Accounts required by the _ReduceOrderWithFreeFunds_ instruction
  *
@@ -39,31 +48,33 @@ export const ReduceOrderWithFreeFundsStruct = new beet.FixableBeetArgsStruct<{
  * @category generated
  */
 export type ReduceOrderWithFreeFundsInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+}
 
-export const reduceOrderWithFreeFundsInstructionDiscriminator = 5;
+export const reduceOrderWithFreeFundsInstructionDiscriminator = 5
 
 /**
  * Creates a _ReduceOrderWithFreeFunds_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category ReduceOrderWithFreeFunds
  * @category generated
  */
 export function createReduceOrderWithFreeFundsInstruction(
   accounts: ReduceOrderWithFreeFundsInstructionAccounts,
-  params: CancelOrderParams,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: ReduceOrderWithFreeFundsInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = ReduceOrderWithFreeFundsStruct.serialize({
     instructionDiscriminator: reduceOrderWithFreeFundsInstructionDiscriminator,
-    params,
-  });
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -85,12 +96,12 @@ export function createReduceOrderWithFreeFundsInstruction(
       isWritable: true,
       isSigner: true,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/Swap.ts
+++ b/typescript/phoenix-sdk/src/instructions/Swap.ts
@@ -5,26 +5,42 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as splToken from "@solana/spl-token";
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
-import { OrderPacket, orderPacketBeet } from "../types/OrderPacket";
+import * as splToken from '@solana/spl-token'
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
+import { OrderPacket, orderPacketBeet } from '../types/OrderPacket'
 
 /**
  * @category Instructions
  * @category Swap
  * @category generated
  */
-export const SwapStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-}>([["instructionDiscriminator", beet.u8]], "SwapInstructionArgs");
+export type SwapInstructionArgs = {
+  orderPacket: OrderPacket
+}
+/**
+ * @category Instructions
+ * @category Swap
+ * @category generated
+ */
+export const SwapStruct = new beet.FixableBeetArgsStruct<
+  SwapInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
+  [
+    ['instructionDiscriminator', beet.u8],
+    ['orderPacket', orderPacketBeet],
+  ],
+  'SwapInstructionArgs'
+)
 /**
  * Accounts required by the _Swap_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
  * @property [_writable_] baseVault Base vault PDA, seeds are [b'vault', market_address, base_mint_address]
@@ -34,40 +50,38 @@ export const SwapStruct = new beet.FixableBeetArgsStruct<{
  * @category generated
  */
 export type SwapInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  baseAccount: web3.PublicKey;
-  quoteAccount: web3.PublicKey;
-  baseVault: web3.PublicKey;
-  quoteVault: web3.PublicKey;
-  tokenProgram?: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  baseAccount: web3.PublicKey
+  quoteAccount: web3.PublicKey
+  baseVault: web3.PublicKey
+  quoteVault: web3.PublicKey
+  tokenProgram?: web3.PublicKey
+}
 
-export const swapInstructionDiscriminator = 0;
+export const swapInstructionDiscriminator = 0
 
 /**
  * Creates a _Swap_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category Swap
  * @category generated
  */
 export function createSwapInstruction(
   accounts: SwapInstructionAccounts,
-  orderPacket: OrderPacket,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: SwapInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
-  const [ixEnum] = SwapStruct.serialize({
+  const [data] = SwapStruct.serialize({
     instructionDiscriminator: swapInstructionDiscriminator,
-  });
-
-  const paramData = orderPacketBeet.toFixedFromValue(orderPacket);
-  const data = Buffer.alloc(ixEnum.length + paramData.byteSize, ixEnum);
-  paramData.write(data, ixEnum.length, orderPacket);
-
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -86,7 +100,7 @@ export function createSwapInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -114,12 +128,12 @@ export function createSwapInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/SwapWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/SwapWithFreeFunds.ts
@@ -5,61 +5,75 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
-import { OrderPacket, orderPacketBeet } from "../types/OrderPacket";
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
+import { OrderPacket, orderPacketBeet } from '../types/OrderPacket'
 
 /**
  * @category Instructions
  * @category SwapWithFreeFunds
  * @category generated
  */
-export const SwapWithFreeFundsStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-}>([["instructionDiscriminator", beet.u8]], "SwapWithFreeFundsInstructionArgs");
+export type SwapWithFreeFundsInstructionArgs = {
+  orderPacket: OrderPacket
+}
+/**
+ * @category Instructions
+ * @category SwapWithFreeFunds
+ * @category generated
+ */
+export const SwapWithFreeFundsStruct = new beet.FixableBeetArgsStruct<
+  SwapWithFreeFundsInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
+  [
+    ['instructionDiscriminator', beet.u8],
+    ['orderPacket', orderPacketBeet],
+  ],
+  'SwapWithFreeFundsInstructionArgs'
+)
 /**
  * Accounts required by the _SwapWithFreeFunds_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [] seat
  * @category Instructions
  * @category SwapWithFreeFunds
  * @category generated
  */
 export type SwapWithFreeFundsInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  seat: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  seat: web3.PublicKey
+}
 
-export const swapWithFreeFundsInstructionDiscriminator = 1;
+export const swapWithFreeFundsInstructionDiscriminator = 1
 
 /**
  * Creates a _SwapWithFreeFunds_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category SwapWithFreeFunds
  * @category generated
  */
 export function createSwapWithFreeFundsInstruction(
   accounts: SwapWithFreeFundsInstructionAccounts,
-  orderPacket: Partial<OrderPacket>,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: SwapWithFreeFundsInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
-  const [ixEnum] = SwapWithFreeFundsStruct.serialize({
+  const [data] = SwapWithFreeFundsStruct.serialize({
     instructionDiscriminator: swapWithFreeFundsInstructionDiscriminator,
-  });
-
-  const paramData = orderPacketBeet.toFixedFromValue(orderPacket);
-  const data = Buffer.alloc(ixEnum.length + paramData.byteSize, ixEnum);
-  paramData.write(data, ixEnum.length, orderPacket);
-
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -78,7 +92,7 @@ export function createSwapWithFreeFundsInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -86,12 +100,12 @@ export function createSwapWithFreeFundsInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/src/instructions/WithdrawFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/WithdrawFunds.ts
@@ -5,33 +5,42 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as splToken from "@solana/spl-token";
-import * as beet from "@metaplex-foundation/beet";
-import * as web3 from "@solana/web3.js";
-import { WithdrawParams, withdrawParamsBeet } from "../types/WithdrawParams";
+import * as splToken from '@solana/spl-token'
+import * as beet from '@metaplex-foundation/beet'
+import * as web3 from '@solana/web3.js'
+import { WithdrawParams, withdrawParamsBeet } from '../types/WithdrawParams'
 
 /**
  * @category Instructions
  * @category WithdrawFunds
  * @category generated
  */
-export const WithdrawFundsStruct = new beet.FixableBeetArgsStruct<{
-  instructionDiscriminator: number;
-  params: WithdrawParams;
-}>(
+export type WithdrawFundsInstructionArgs = {
+  withdrawFundsParams: WithdrawParams
+}
+/**
+ * @category Instructions
+ * @category WithdrawFunds
+ * @category generated
+ */
+export const WithdrawFundsStruct = new beet.FixableBeetArgsStruct<
+  WithdrawFundsInstructionArgs & {
+    instructionDiscriminator: number
+  }
+>(
   [
-    ["instructionDiscriminator", beet.u8],
-    ["params", withdrawParamsBeet],
+    ['instructionDiscriminator', beet.u8],
+    ['withdrawFundsParams', withdrawParamsBeet],
   ],
-  "WithdrawFundsInstructionArgs"
-);
+  'WithdrawFundsInstructionArgs'
+)
 /**
  * Accounts required by the _WithdrawFunds_ instruction
  *
  * @property [] phoenixProgram Phoenix program
  * @property [] logAuthority Phoenix log authority
  * @property [_writable_] market This account holds the market state
- * @property [_writable_, **signer**] trader
+ * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account
  * @property [_writable_] quoteAccount Trader quote token account
  * @property [_writable_] baseVault Base vault PDA, seeds are [b'vault', market_address, base_mint_address]
@@ -41,36 +50,38 @@ export const WithdrawFundsStruct = new beet.FixableBeetArgsStruct<{
  * @category generated
  */
 export type WithdrawFundsInstructionAccounts = {
-  phoenixProgram: web3.PublicKey;
-  logAuthority: web3.PublicKey;
-  market: web3.PublicKey;
-  trader: web3.PublicKey;
-  baseAccount: web3.PublicKey;
-  quoteAccount: web3.PublicKey;
-  baseVault: web3.PublicKey;
-  quoteVault: web3.PublicKey;
-  tokenProgram?: web3.PublicKey;
-};
+  phoenixProgram: web3.PublicKey
+  logAuthority: web3.PublicKey
+  market: web3.PublicKey
+  trader: web3.PublicKey
+  baseAccount: web3.PublicKey
+  quoteAccount: web3.PublicKey
+  baseVault: web3.PublicKey
+  quoteVault: web3.PublicKey
+  tokenProgram?: web3.PublicKey
+}
 
-export const withdrawFundsInstructionDiscriminator = 12;
+export const withdrawFundsInstructionDiscriminator = 12
 
 /**
  * Creates a _WithdrawFunds_ instruction.
  *
  * @param accounts that will be accessed while the instruction is processed
+ * @param args to provide as instruction data to the program
+ *
  * @category Instructions
  * @category WithdrawFunds
  * @category generated
  */
 export function createWithdrawFundsInstruction(
   accounts: WithdrawFundsInstructionAccounts,
-  params: WithdrawParams,
-  programId = new web3.PublicKey("phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH")
+  args: WithdrawFundsInstructionArgs,
+  programId = new web3.PublicKey('phnxNHfGNVjpVVuHkceK3MgwZ1bW25ijfWACKhVFbBH')
 ) {
   const [data] = WithdrawFundsStruct.serialize({
     instructionDiscriminator: withdrawFundsInstructionDiscriminator,
-    params,
-  });
+    ...args,
+  })
   const keys: web3.AccountMeta[] = [
     {
       pubkey: accounts.phoenixProgram,
@@ -89,7 +100,7 @@ export function createWithdrawFundsInstruction(
     },
     {
       pubkey: accounts.trader,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {
@@ -117,12 +128,12 @@ export function createWithdrawFundsInstruction(
       isWritable: false,
       isSigner: false,
     },
-  ];
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,
     keys,
     data,
-  });
-  return ix;
+  })
+  return ix
 }

--- a/typescript/phoenix-sdk/tests/test.ts
+++ b/typescript/phoenix-sdk/tests/test.ts
@@ -91,7 +91,7 @@ async function main() {
       quoteVault: market.header.quoteParams.vaultKey,
       baseVault: market.header.baseParams.vaultKey,
     },
-    { __kind: "ImmediateOrCancel", ...ioc }
+    { orderPacket: { __kind: "ImmediateOrCancel", ...ioc } }
   );
 
   let txId = await sendAndConfirmTransaction(


### PR DESCRIPTION
Breaking Changes:

Anywhere we invoke the swap function directly (or any new order instruction), we will need to wrap the arg with `orderPacket: params`

Before:
```
  let ix = createSwapInstruction(
    // accounts
    {
        ...
    },
    // params
    { __kind: "ImmediateOrCancel", ...ioc } 
  );

```

After:
```
  let ix = createSwapInstruction(
    // accounts
    {
        ...
    },
    // params
    { orderPacket: { __kind: "ImmediateOrCancel", ...ioc } }
  );

```