### PR TITLE
Remove subscriptions

### DIFF
--- a/typescript/phoenix-sdk/package.json
+++ b/typescript/phoenix-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/phoenix-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "TypeScript SDK for Phoenix",
   "author": "Ellipsis Labs",
   "repository": "https://github.com/Ellipsis-Labs/phoenix-sdk",

--- a/typescript/phoenix-sdk/package.json
+++ b/typescript/phoenix-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/phoenix-sdk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "TypeScript SDK for Phoenix",
   "author": "Ellipsis Labs",
   "repository": "https://github.com/Ellipsis-Labs/phoenix-sdk",

--- a/typescript/phoenix-sdk/src/client.ts
+++ b/typescript/phoenix-sdk/src/client.ts
@@ -76,45 +76,4 @@ export class Client {
         : undefined,
     });
   }
-
-  /**
-   * Subscribes to all market and trader updates
-   *
-   * @param callback The callback that fires when there is an update (Optional)
-   */
-  subscribe(callback?: (client: Client) => void) {
-    for (const market of this.markets) {
-      market.subscribe(this.connection, (market: Market) => {
-        const index = this.markets.findIndex(
-          (m) => m.address.toBase58() === market.address.toBase58()
-        );
-        this.markets[index] = market;
-
-        if (callback) callback(this);
-      });
-    }
-
-    if (this.trader) {
-      this.trader.subscribe(this.connection, (trader: Trader) => {
-        this.trader = trader;
-
-        if (callback) callback(this);
-      });
-    }
-  }
-
-  /**
-   * Unsubscribes from all subscriptions when the client is no longer needed
-   */
-  async unsubscribe() {
-    await Promise.all(
-      this.markets.map(async (market) => {
-        await market.unsubscribe(this.connection);
-      })
-    );
-
-    if (this.trader) {
-      await this.trader.unsubscribe(this.connection);
-    }
-  }
 }

--- a/typescript/phoenix-sdk/src/client.ts
+++ b/typescript/phoenix-sdk/src/client.ts
@@ -78,15 +78,28 @@ export class Client {
   }
 
   /**
-   * Subscribes to all market and trader changes
+   * Subscribes to all market and trader updates
+   *
+   * @param callback The callback that fires when there is an update (Optional)
    */
-  subscribe() {
+  subscribe(callback?: (client: Client) => void) {
     for (const market of this.markets) {
-      market.subscribe(this.connection);
+      market.subscribe(this.connection, (market: Market) => {
+        const index = this.markets.findIndex(
+          (m) => m.address.toBase58() === market.address.toBase58()
+        );
+        this.markets[index] = market;
+
+        if (callback) callback(this);
+      });
     }
 
     if (this.trader) {
-      this.trader.subscribe(this.connection);
+      this.trader.subscribe(this.connection, (trader: Trader) => {
+        this.trader = trader;
+
+        if (callback) callback(this);
+      });
     }
   }
 

--- a/typescript/phoenix-sdk/src/market.ts
+++ b/typescript/phoenix-sdk/src/market.ts
@@ -252,11 +252,14 @@ export class Market {
    * Subscribes to updates on the market
    *
    * @param connection The Solana `Connection` object
+   * @param callback The callback function that fires when the market is updated (Optional)
    */
-  subscribe(connection: Connection) {
+  subscribe(connection: Connection, callback?: (market: Market) => void) {
     const subId = connection.onAccountChange(this.address, (account) => {
       const marketData = deserializeMarketData(account.data);
       this.data = marketData;
+
+      if (callback) callback(this);
     });
     this.subscriptions.push(subId);
   }

--- a/typescript/phoenix-sdk/src/market.ts
+++ b/typescript/phoenix-sdk/src/market.ts
@@ -64,7 +64,6 @@ export class Market {
   baseToken: Token;
   quoteToken: Token;
   data: MarketData;
-  private subscriptions: Array<number>;
 
   private constructor({
     name,
@@ -84,7 +83,6 @@ export class Market {
     this.baseToken = baseToken;
     this.quoteToken = quoteToken;
     this.data = data;
-    this.subscriptions = [];
   }
 
   /**
@@ -162,16 +160,16 @@ export class Market {
    * Refreshes the market data
    *
    * @param connection The Solana `Connection` object
+   *
+   * @returns The refreshed Market
    */
-  async refresh(connection: Connection) {
+  async refresh(connection: Connection): Promise<Market> {
     const account = await connection.getAccountInfo(this.address);
-    if (!account)
-      throw new Error(
-        "Account not found for market: " + this.address.toBase58()
-      );
     const data = Buffer.from(account.data);
     const marketData = deserializeMarketData(data);
     this.data = marketData;
+
+    return this;
   }
 
   /**
@@ -246,36 +244,5 @@ export class Market {
       side,
       inAmount,
     });
-  }
-
-  /**
-   * Subscribes to updates on the market
-   *
-   * @param connection The Solana `Connection` object
-   * @param callback The callback function that fires when the market is updated (Optional)
-   */
-  subscribe(connection: Connection, callback?: (market: Market) => void) {
-    const subId = connection.onAccountChange(this.address, (account) => {
-      const marketData = deserializeMarketData(account.data);
-      this.data = marketData;
-
-      if (callback) callback(this);
-    });
-    this.subscriptions.push(subId);
-  }
-
-  /**
-   * Unsubscribes from updates when the market is no longer needed
-   *
-   * @param connection The Solana `Connection` object
-   */
-  async unsubscribe(connection: Connection) {
-    await Promise.all(
-      this.subscriptions.map((subId) =>
-        connection.removeAccountChangeListener(subId)
-      )
-    );
-
-    this.subscriptions = [];
   }
 }

--- a/typescript/phoenix-sdk/src/trader.ts
+++ b/typescript/phoenix-sdk/src/trader.ts
@@ -82,8 +82,9 @@ export class Trader {
    * Subscribes to trader updates
    *
    * @param connection The Solana `Connection` object
+   * @param callback The callback function that fires when the trader is updated (Optional)
    */
-  async subscribe(connection: Connection) {
+  async subscribe(connection: Connection, callback?: (trader: Trader) => void) {
     // Subscribe to token balance updates in promise.all
     await Promise.all(
       Object.keys(this.tokenBalances).map(async (mintKey) => {
@@ -103,6 +104,8 @@ export class Trader {
               accountInfo.data,
               this.tokenBalances[mintKey].decimals
             );
+
+            if (callback) callback(this);
           }
         );
         this.subscriptions.push(subId);

--- a/typescript/phoenix-sdk/src/trader.ts
+++ b/typescript/phoenix-sdk/src/trader.ts
@@ -6,12 +6,10 @@ import { Token } from "./token";
 export class Trader {
   pubkey: PublicKey;
   tokenBalances: Record<string, TokenAmount>;
-  private subscriptions: Array<number>;
 
   private constructor(publicKey: PublicKey) {
     this.pubkey = publicKey;
     this.tokenBalances = {};
-    this.subscriptions = [];
   }
 
   /**
@@ -56,8 +54,10 @@ export class Trader {
    * Refreshes the trader data
    *
    * @param connection The Solana `Connection` object
+   *
+   * @returns The refreshed Trader
    */
-  async refresh(connection: Connection) {
+  async refresh(connection: Connection): Promise<Trader> {
     // Refresh token balances
     await Promise.all(
       Object.keys(this.tokenBalances).map(async (mintKey) => {
@@ -76,56 +76,8 @@ export class Trader {
         );
       })
     );
-  }
 
-  /**
-   * Subscribes to trader updates
-   *
-   * @param connection The Solana `Connection` object
-   * @param callback The callback function that fires when the trader is updated (Optional)
-   */
-  async subscribe(connection: Connection, callback?: (trader: Trader) => void) {
-    // Subscribe to token balance updates in promise.all
-    await Promise.all(
-      Object.keys(this.tokenBalances).map(async (mintKey) => {
-        const tokenAccounts = await connection.getTokenAccountsByOwner(
-          this.pubkey,
-          {
-            programId: TOKEN_PROGRAM_ID,
-            mint: new PublicKey(mintKey),
-          }
-        );
-
-        const tokenAccount = tokenAccounts.value[0];
-        const subId = connection.onAccountChange(
-          tokenAccount.pubkey,
-          (accountInfo) => {
-            this.tokenBalances[mintKey] = getTokenAmountFromBuffer(
-              accountInfo.data,
-              this.tokenBalances[mintKey].decimals
-            );
-
-            if (callback) callback(this);
-          }
-        );
-        this.subscriptions.push(subId);
-      })
-    );
-  }
-
-  /**
-   * Unsubscribes from updates when the trader is no longer needed
-   *
-   * @param connection The Solana `Connection` object
-   */
-  async unsubscribe(connection: Connection) {
-    await Promise.all(
-      this.subscriptions.map((subId) =>
-        connection.removeAccountChangeListener(subId)
-      )
-    );
-
-    this.subscriptions = [];
+    return this;
   }
 }
 

--- a/typescript/phoenix-sdk/tests/watch.ts
+++ b/typescript/phoenix-sdk/tests/watch.ts
@@ -8,7 +8,7 @@ export async function watch() {
 
   phoenix.subscribe();
 
-  const market = phoenix.markets.find((market) => market.name === "SOL/USDC");
+  const market = phoenix.markets.find((market) => market.name === "wSOL/USDC");
   if (!market) throw new Error("Market not found");
 
   let lastLadder: Phoenix.UiLadder | null = null;

--- a/typescript/phoenix-sdk/tests/watch.ts
+++ b/typescript/phoenix-sdk/tests/watch.ts
@@ -6,8 +6,6 @@ export async function watch() {
   const connection = new Connection("https://qn-devnet.solana.fm/");
   const phoenix = await Phoenix.Client.create(connection);
 
-  phoenix.subscribe();
-
   const market = phoenix.markets.find((market) => market.name === "wSOL/USDC");
   if (!market) throw new Error("Market not found");
 
@@ -23,10 +21,9 @@ export async function watch() {
       updates++;
     }
 
+    await market.refresh(connection);
     await new Promise((res) => setTimeout(res, 500));
   }
-
-  phoenix.unsubscribe();
 }
 
 (async function () {


### PR DESCRIPTION
Subscriptions are a bit messy to begin with, and after fighting with React for the day I've realized that leaving it up to the client whether they'd like to subscribe or poll is the best way to go. We provide a manual way for the client to refresh state and we leave it at that.

This approach is much cleaner code wise and resolved all dynamic data problems in our react app