### PR TITLE
Jli/rust pll instructions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2734,6 +2734,7 @@ dependencies = [
  "itertools",
  "num-traits",
  "phoenix-sdk-core",
+ "phoenix-seat-manager",
  "phoenix-v1",
  "rand 0.7.3",
  "rust_decimal",
@@ -2742,6 +2743,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "solana-transaction-status",
+ "spl-associated-token-account",
  "spl-token",
  "tokio",
 ]
@@ -2760,6 +2762,26 @@ dependencies = [
  "rust_decimal_macros",
  "solana-program",
  "solana-sdk",
+]
+
+[[package]]
+name = "phoenix-seat-manager"
+version = "0.1.0"
+dependencies = [
+ "borsh 0.9.3",
+ "bytemuck",
+ "ellipsis-macros",
+ "itertools",
+ "lib-sokoban",
+ "num_enum",
+ "phoenix-v1",
+ "shank",
+ "solana-program",
+ "solana-security-txt",
+ "spl-associated-token-account",
+ "spl-token",
+ "static_assertions",
+ "thiserror",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "devnet-token-faucet",
  "ellipsis-client",
  "phoenix-sdk",
+ "phoenix-seat-manager",
  "phoenix-v1",
  "rand 0.7.3",
  "shellexpand",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,3 +31,4 @@ rust_decimal = "1.26.1"
 rust_decimal_macros = "1.26"
 itertools = "0.10.5"
 bytemuck = "1.11.0"
+phoenix-seat-manager = { path = "../../phoenix-seat-manager" }

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -26,3 +26,4 @@ borsh = { workspace = true }
 phoenix-v1 = { workspace = true }
 phoenix-sdk = { path = "../phoenix-sdk" }
 devnet-token-faucet = { git = "https://github.com/Ellipsis-Labs/devnet-token-faucet" }
+phoenix-seat-manager = { workspace = true }

--- a/rust/examples/src/bin/place_order.rs
+++ b/rust/examples/src/bin/place_order.rs
@@ -1,0 +1,169 @@
+use std::str::FromStr;
+
+use phoenix::state::Side;
+use phoenix_sdk::sdk_client::SDKClient;
+use solana_sdk::{
+    instruction::Instruction,
+    program_pack::Pack,
+    pubkey::Pubkey,
+    signature::{read_keypair_file, Keypair},
+    signer::Signer,
+};
+use spl_token::state::Mint;
+
+#[tokio::main]
+async fn main() {
+    // Connect to the solana network and get the market address
+    let network_url = "https://api.devnet.solana.com";
+    let market = Pubkey::from_str("CS2H8nbAVVEUHWPF5extCSymqheQdkd4d7thik6eet9N").unwrap();
+
+    let trader = Keypair::new();
+    println!("Trader pubkey: {}", trader.pubkey());
+    let sdk = SDKClient::new(&market, &trader, network_url).await;
+    // Alternatively, read from keypair file for the payer
+    // let path = "~/.config/solana/id.json";
+    // let auth_payer = read_keypair_file(&*shellexpand::tilde(path)).unwrap();
+
+    println!("trader {}", sdk.trader);
+
+    // Only relevant for devnet
+    let instructions = create_airdrop_spl_ixs(&sdk, &trader.pubkey())
+        .await
+        .unwrap();
+    sdk.client
+        .request_airdrop(&trader.pubkey(), 1_500_000_000)
+        .await
+        .unwrap();
+    sdk.client
+        .sign_send_instructions(instructions, vec![])
+        .await
+        .unwrap();
+
+    // Send limit order instruction bundle
+    let limit_order_new_maker_ixs = sdk
+        .get_post_only_new_maker_ixs(sdk.float_price_to_ticks(500.0), Side::Bid, 1_000)
+        .await;
+    println!("Ix Len: {}", limit_order_new_maker_ixs.len());
+    let sig = sdk
+        .client
+        .sign_send_instructions(limit_order_new_maker_ixs, vec![])
+        .await
+        .unwrap();
+
+    println!("Tx Signature: {}", sig);
+}
+
+// Only needed for devnet testing
+pub async fn create_airdrop_spl_ixs(
+    sdk_client: &SDKClient,
+    recipient_pubkey: &Pubkey,
+) -> Option<Vec<Instruction>> {
+    // Get base and quote mints from market metadata
+    let market_metadata = sdk_client.get_active_market_metadata();
+    let base_mint = market_metadata.base_mint;
+    let quote_mint = market_metadata.quote_mint;
+
+    let base_mint_account = Mint::unpack(
+        &sdk_client
+            .client
+            .get_account_data(&base_mint)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+
+    let quote_mint_account = Mint::unpack(
+        &sdk_client
+            .client
+            .get_account_data(&quote_mint)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+
+    let quote_mint_authority = quote_mint_account.mint_authority.unwrap();
+    let base_mint_authority = base_mint_account.mint_authority.unwrap();
+
+    if sdk_client
+        .client
+        .get_account(&quote_mint_authority)
+        .await
+        .unwrap()
+        .owner
+        != devnet_token_faucet::id()
+    {
+        return None;
+    }
+
+    if sdk_client
+        .client
+        .get_account(&base_mint_authority)
+        .await
+        .unwrap()
+        .owner
+        != devnet_token_faucet::id()
+    {
+        return None;
+    }
+
+    // Get or create the ATA for the recipient. If doesn't exist, create token account
+    let mut instructions = vec![];
+
+    let recipient_ata_base =
+        spl_associated_token_account::get_associated_token_address(recipient_pubkey, &base_mint);
+
+    if sdk_client
+        .client
+        .get_account(&recipient_ata_base)
+        .await
+        .is_err()
+    {
+        println!("Error retrieving ATA. Creating ATA");
+        instructions.push(
+            spl_associated_token_account::instruction::create_associated_token_account(
+                &sdk_client.client.payer.pubkey(),
+                recipient_pubkey,
+                &base_mint,
+                &spl_token::id(),
+            ),
+        )
+    };
+
+    let recipient_ata_quote =
+        spl_associated_token_account::get_associated_token_address(recipient_pubkey, &quote_mint);
+
+    if sdk_client
+        .client
+        .get_account(&recipient_ata_quote)
+        .await
+        .is_err()
+    {
+        println!("Error retrieving ATA. Creating ATA");
+        instructions.push(
+            spl_associated_token_account::instruction::create_associated_token_account(
+                &sdk_client.client.payer.pubkey(),
+                recipient_pubkey,
+                &quote_mint,
+                &spl_token::id(),
+            ),
+        )
+    };
+
+    instructions.push(devnet_token_faucet::airdrop_spl_with_mint_pdas_ix(
+        &devnet_token_faucet::id(),
+        &base_mint,
+        &base_mint_authority,
+        recipient_pubkey,
+        (5000.0 * 1e9) as u64,
+    ));
+
+    instructions.push(devnet_token_faucet::airdrop_spl_with_mint_pdas_ix(
+        &devnet_token_faucet::id(),
+        &quote_mint,
+        &quote_mint_authority,
+        recipient_pubkey,
+        (500000.0 * 1e6) as u64,
+    ));
+
+    Some(instructions)
+}

--- a/rust/examples/src/bin/place_order.rs
+++ b/rust/examples/src/bin/place_order.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use phoenix::state::Side;
 use phoenix_sdk::sdk_client::SDKClient;
+#[allow(unused_imports)]
 use solana_sdk::{
     instruction::Instruction,
     program_pack::Pack,
@@ -10,7 +11,6 @@ use solana_sdk::{
     signer::Signer,
 };
 use spl_token::state::Mint;
-
 #[tokio::main]
 async fn main() {
     // Connect to the solana network and get the market address

--- a/rust/phoenix-sdk/Cargo.toml
+++ b/rust/phoenix-sdk/Cargo.toml
@@ -30,3 +30,5 @@ rust_decimal_macros = { workspace = true }
 bytemuck = { workspace = true }
 itertools = "0.10.5"
 phoenix-sdk-core = { version = "0.1.0", path = "../phoenix-sdk-core" }
+spl-associated-token-account = { workspace = true }
+phoenix-seat-manager = { workspace = true }

--- a/rust/phoenix-sdk/src/lib.rs
+++ b/rust/phoenix-sdk/src/lib.rs
@@ -4,3 +4,4 @@ pub use phoenix_sdk_core::orderbook;
 pub mod price_listeners;
 pub mod sdk_client;
 pub mod transaction_executor;
+pub mod utils;

--- a/rust/phoenix-sdk/src/sdk_client.rs
+++ b/rust/phoenix-sdk/src/sdk_client.rs
@@ -555,12 +555,11 @@ impl SDKClient {
             instructions.push(claim_seat_ix);
         }
         instructions.push(limit_order_ix);
-
-        return instructions;
+        instructions
     }
 
     // Useful if known that trader has an ATA for the base or quote through prior interactions but may have been evicted
-    pub async fn get_limit_order_existing_maker(
+    pub async fn get_limit_order_existing_maker_ixs(
         &self,
         trader: &Pubkey,
         price: u64,
@@ -578,7 +577,6 @@ impl SDKClient {
             instructions.push(claim_seat_ix);
         }
         instructions.push(limit_order_ix);
-
-        return instructions;
+        instructions
     }
 }

--- a/rust/phoenix-sdk/src/sdk_client.rs
+++ b/rust/phoenix-sdk/src/sdk_client.rs
@@ -573,7 +573,7 @@ impl SDKClient {
 
         let limit_order_ix = self.get_limit_order_ix(price, side, size);
 
-        let mut instructions = Vec::with_capacity(4);
+        let mut instructions = Vec::with_capacity(2);
 
         if let Some(claim_seat_ix) = claim_seat_ix_option {
             instructions.push(claim_seat_ix);
@@ -630,7 +630,7 @@ impl SDKClient {
 
         let post_only_ix = self.get_post_only_ix(price, side, size);
 
-        let mut instructions = Vec::with_capacity(4);
+        let mut instructions = Vec::with_capacity(2);
 
         if let Some(claim_seat_ix) = claim_seat_ix_option {
             instructions.push(claim_seat_ix);

--- a/rust/phoenix-sdk/src/utils.rs
+++ b/rust/phoenix-sdk/src/utils.rs
@@ -26,7 +26,7 @@ pub async fn create_ata_ix_if_needed(
         }
     }
 
-    return None;
+    None
 }
 
 pub async fn create_claim_seat_ix_if_needed(
@@ -43,5 +43,5 @@ pub async fn create_claim_seat_ix_if_needed(
         }
     }
 
-    return None;
+    None
 }

--- a/rust/phoenix-sdk/src/utils.rs
+++ b/rust/phoenix-sdk/src/utils.rs
@@ -1,0 +1,47 @@
+use ellipsis_client::EllipsisClient;
+use phoenix::program::get_seat_address;
+use phoenix_seat_manager::instruction_builders::create_claim_seat_instruction;
+use solana_program::{instruction::Instruction, pubkey::Pubkey};
+use spl_associated_token_account::{
+    get_associated_token_address, instruction::create_associated_token_account,
+};
+
+pub async fn create_ata_ix_if_needed(
+    client: &EllipsisClient,
+    payer: &Pubkey,
+    trader: &Pubkey,
+    mint: &Pubkey,
+) -> Option<Instruction> {
+    let ata_address = get_associated_token_address(trader, mint);
+    let ata_account = client.get_account(&ata_address).await;
+
+    if let Ok(ata_account) = ata_account {
+        if ata_account.data.is_empty() {
+            return Some(create_associated_token_account(
+                payer,
+                trader,
+                mint,
+                &spl_token::ID,
+            ));
+        }
+    }
+
+    return None;
+}
+
+pub async fn create_claim_seat_ix_if_needed(
+    client: &EllipsisClient,
+    market: &Pubkey,
+    trader: &Pubkey,
+) -> Option<Instruction> {
+    let seat_address = get_seat_address(market, trader).0;
+    let seat_account = client.get_account(&seat_address).await;
+
+    if let Ok(seat_account) = seat_account {
+        if seat_account.data.is_empty() {
+            return Some(create_claim_seat_instruction(trader, market));
+        }
+    }
+
+    return None;
+}

--- a/rust/phoenix-sdk/src/utils.rs
+++ b/rust/phoenix-sdk/src/utils.rs
@@ -16,17 +16,16 @@ pub async fn create_ata_ix_if_needed(
     let ata_account = client.get_account(&ata_address).await;
 
     if let Ok(ata_account) = ata_account {
-        if ata_account.data.is_empty() {
-            return Some(create_associated_token_account(
-                payer,
-                trader,
-                mint,
-                &spl_token::ID,
-            ));
+        if !ata_account.data.is_empty() {
+            return None;
         }
     }
-
-    None
+    Some(create_associated_token_account(
+        payer,
+        trader,
+        mint,
+        &spl_token::ID,
+    ))
 }
 
 pub async fn create_claim_seat_ix_if_needed(
@@ -38,10 +37,10 @@ pub async fn create_claim_seat_ix_if_needed(
     let seat_account = client.get_account(&seat_address).await;
 
     if let Ok(seat_account) = seat_account {
-        if seat_account.data.is_empty() {
-            return Some(create_claim_seat_instruction(trader, market));
+        if !seat_account.data.is_empty() {
+            return None;
         }
     }
 
-    None
+    Some(create_claim_seat_instruction(trader, market))
 }


### PR DESCRIPTION
Main components:
- check for ATAs and create instructions for their creation if needed
- check for seat and create instruction for claim seat if needed
- wrap above with create limit order and post only order, respectively, to create encompassing ix bundle
-  use encompassing ix bundle (appropriate for new users) in the default SDK send methods