### PR TITLE
Refactor parse events to be market agnostic

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-sdk-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "borsh 0.9.3",

--- a/rust/phoenix-sdk-core/Cargo.toml
+++ b/rust/phoenix-sdk-core/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "phoenix-sdk-core"
-version = "0.3.1"
+version = "0.3.2"
 description = "Core SDK for interacting with the Phoenix program"
 edition = "2021"
 license = "MIT"

--- a/rust/phoenix-sdk-core/src/sdk_client_core.rs
+++ b/rust/phoenix-sdk-core/src/sdk_client_core.rs
@@ -364,7 +364,7 @@ impl SDKClientCore {
         for event in events.iter() {
             let header_event =
                 PhoenixMarketEvent::try_from_slice(&event[..AUDIT_LOG_HEADER_LEN]).ok()?;
-            let mut header = match header_event {
+            let header = match header_event {
                 PhoenixMarketEvent::Header(header) => Some(header),
                 _ => {
                     panic!("Expected a header event");
@@ -381,8 +381,6 @@ impl SDKClientCore {
                         return None;
                     }
                 };
-            // Zero out the total_events field so we can group the headers
-            header.total_events = 0;
 
             market_events.push(RawPhoenixEvent {
                 header: RawPhoenixHeader {

--- a/rust/phoenix-sdk/Cargo.toml
+++ b/rust/phoenix-sdk/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "phoenix-sdk"
-version = "0.3.1"
+version = "0.3.2"
 description = "SDK for interacting with the Phoenix program"
 edition = "2021"
 license = "MIT"
@@ -29,5 +29,5 @@ rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }
 bytemuck = { workspace = true }
 itertools = "0.10.5"
-phoenix-sdk-core = { version = "0.3.1", path = "../phoenix-sdk-core" }
+phoenix-sdk-core = { version = "0.3.2", path = "../phoenix-sdk-core" }
 serde = { workspace = true }

--- a/typescript/phoenix-sdk/examples/simpleMarketMaker.ts
+++ b/typescript/phoenix-sdk/examples/simpleMarketMaker.ts
@@ -102,7 +102,7 @@ export async function simpleMarketMaker(privateKeyPath: string) {
   );
 
   let count = 0;
-  
+
   while (true) {
     const cancelAll = Phoenix.createCancelAllOrdersInstructionWithClient(
       client,


### PR DESCRIPTION
parse_events_from_transaction requires you to pass in a market key, but this is bad UX for the CLI. Ideally you just pass in a transaction hash and it spits out all events for all markets.
