### PR TITLE
rust sdk: create permissionless limit order helper functions and update for SDK Changes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-sdk"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-sdk-core"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "borsh 0.9.3",
@@ -2777,6 +2777,8 @@ dependencies = [
 [[package]]
 name = "phoenix-seat-manager"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5436d4bfc3dcd89729d9098e85f00f6d2239e852cb9ba2f48154b5ffe3fd36e"
 dependencies = [
  "borsh 0.9.3",
  "bytemuck",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1160,16 +1160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
 
 [[package]]
-name = "devnet-token-faucet"
-version = "0.1.1"
-source = "git+https://github.com/Ellipsis-Labs/devnet-token-faucet#39b3b09b202eca299ad49e3fb6e9b6401e5453bf"
-dependencies = [
- "anchor-lang",
- "anchor-spl",
- "spl-associated-token-account",
-]
-
-[[package]]
 name = "dialoguer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,17 +1469,22 @@ name = "examples"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "borsh 0.9.3",
  "bs58 0.4.0",
  "bytemuck",
  "clap 3.2.23",
- "devnet-token-faucet",
  "ellipsis-client",
+ "generic-token-faucet",
  "phoenix-sdk",
+ "phoenix-seat-manager",
  "phoenix-v1",
  "rand 0.7.3",
+ "reqwest",
+ "serde_json",
  "shellexpand",
  "solana-account-decoder",
+ "solana-cli-config",
  "solana-client",
  "solana-program",
  "solana-sdk",
@@ -1679,6 +1674,17 @@ dependencies = [
  "serde",
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "generic-token-faucet"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5771d5b8ad17607a958ba26902150157f4fcd681c27a314cf6c5d55d31231f15"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "spl-associated-token-account",
 ]
 
 [[package]]
@@ -2734,6 +2740,7 @@ dependencies = [
  "itertools",
  "num-traits",
  "phoenix-sdk-core",
+ "phoenix-seat-manager",
  "phoenix-v1",
  "rand 0.7.3",
  "rust_decimal",
@@ -2743,6 +2750,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "solana-transaction-status",
+ "spl-associated-token-account",
  "spl-token",
  "tokio",
 ]
@@ -2764,6 +2772,26 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "spl-token",
+]
+
+[[package]]
+name = "phoenix-seat-manager"
+version = "0.1.0"
+dependencies = [
+ "borsh 0.9.3",
+ "bytemuck",
+ "ellipsis-macros",
+ "itertools",
+ "lib-sokoban",
+ "num_enum",
+ "phoenix-v1",
+ "shank",
+ "solana-program",
+ "solana-security-txt",
+ "spl-associated-token-account",
+ "spl-token",
+ "static_assertions",
+ "thiserror",
 ]
 
 [[package]]
@@ -3220,10 +3248,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3233,6 +3263,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util 0.7.7",
  "tower-service",
@@ -3534,9 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,3 +32,4 @@ rust_decimal_macros = "1.26"
 itertools = "0.10.5"
 bytemuck = "1.11.0"
 serde = "^1.0.63"
+phoenix-seat-manager = { path = "../../phoenix-seat-manager" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,4 +33,3 @@ itertools = "0.10.5"
 bytemuck = "1.11.0"
 serde = "^1.0.63"
 phoenix-seat-manager = "0.1.0"
-

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,4 +32,5 @@ rust_decimal_macros = "1.26"
 itertools = "0.10.5"
 bytemuck = "1.11.0"
 serde = "^1.0.63"
-phoenix-seat-manager = { path = "../../phoenix-seat-manager" }
+phoenix-seat-manager = "0.1.0"
+

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -25,4 +25,9 @@ shellexpand = { workspace = true }
 borsh = { workspace = true }
 phoenix-v1 = { workspace = true }
 phoenix-sdk = { path = "../phoenix-sdk" }
-devnet-token-faucet = { git = "https://github.com/Ellipsis-Labs/devnet-token-faucet" }
+generic-token-faucet = "0.1.2"
+phoenix-seat-manager = { workspace = true }
+solana-cli-config = "1.14.7"
+reqwest = "0.11.14"
+serde_json = "1.0.94"
+bincode = "1.3.3"

--- a/rust/examples/src/bin/place_order.rs
+++ b/rust/examples/src/bin/place_order.rs
@@ -1,0 +1,206 @@
+use std::str::FromStr;
+
+use ellipsis_client::EllipsisClient;
+use phoenix::state::Side;
+use phoenix_sdk::sdk_client::SDKClient;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::account::Account;
+use solana_sdk::commitment_config::CommitmentConfig;
+#[allow(unused_imports)]
+use solana_sdk::{
+    instruction::Instruction,
+    program_pack::Pack,
+    pubkey::Pubkey,
+    signature::{read_keypair_file, Keypair},
+    signer::Signer,
+};
+use spl_associated_token_account::instruction::create_associated_token_account;
+use spl_token::state::Mint;
+#[tokio::main]
+async fn main() {
+    // Connect to the Solana network and identify the market you want to interact with, using phoenix-cli, for example.
+    let network_url = "https://api.devnet.solana.com";
+    let market_pubkey = Pubkey::from_str("CS2H8nbAVVEUHWPF5extCSymqheQdkd4d7thik6eet9N").unwrap();
+
+    let trader = Keypair::new();
+    let rpc_client =
+        RpcClient::new_with_commitment(network_url.to_string(), CommitmentConfig::confirmed());
+    // Create an EllipsisClient with a payer, here the trader keypair.
+    // Alternatively, read from keypair file for the payer
+    // let path = "~/.config/solana/id.json";
+    // let auth_payer = read_keypair_file(&*shellexpand::tilde(path)).unwrap();
+    let client = EllipsisClient::from_rpc(rpc_client, &trader).unwrap();
+    println!("Trader pubkey: {}", trader.pubkey());
+    // Create an SDKClient instance using the recommended method. If you only needed a specific known market, you can also use SDKClient::new_with_market_keys
+    let sdk = SDKClient::new_from_ellipsis_client_with_all_markets(client)
+        .await
+        .unwrap();
+
+    println!("trader {}", sdk.trader);
+
+    // This instruction only works on devnet. It requests an airdrop of devnet SOL to pay for transaction fees.
+    sdk.client
+        .request_airdrop(&trader.pubkey(), 1_000_000_000)
+        .await
+        .unwrap();
+    // These instructions only work on devnet. They trigger an airdrop from the generic-token-faucet (https://github.com/Ellipsis-Labs/generic-token-faucet) for the base and quote tokens for the supplied market, used for testing trades.
+    let instructions = create_airdrop_spl_ixs(&sdk, &market_pubkey, &trader.pubkey())
+        .await
+        .unwrap();
+    sdk.client
+        .sign_send_instructions(instructions, vec![])
+        .await
+        .unwrap();
+
+    // Send limit order instruction bundle:
+    // - Create the associated token account, if needed, for both base and quote tokens
+    // - Claim a seat on the market, if needed
+    // - Place the post only order
+    let limit_order_new_maker_ixs = sdk
+        .get_post_only_new_maker_ixs(
+            &market_pubkey,
+            sdk.float_price_to_ticks_rounded_down(&market_pubkey, 500.0)
+                .unwrap(),
+            Side::Bid,
+            1_000,
+        )
+        .await
+        .unwrap();
+    println!("Ix Len: {}", limit_order_new_maker_ixs.len());
+    let sig = sdk
+        .client
+        .sign_send_instructions(limit_order_new_maker_ixs, vec![])
+        .await
+        .unwrap();
+
+    println!(
+        "Link to view transaction: https://beta.solscan.io/tx/{}?cluster=devnet",
+        sig
+    );
+
+    // After you have been setup as a maker on the market (handled above), you can place limit orders by sending the limit order instruction directly.
+    // Note that if your seat has been evicted, you will need to claim a new seat before placing a new order.
+    // Instructions for claiming a seat can be created with the create_claim_seat_ix_if_needed function.
+
+    for i in 0..5 {
+        let limit_order_ix = sdk
+            .get_limit_order_ix(
+                &market_pubkey,
+                sdk.float_price_to_ticks_rounded_down(&market_pubkey, 500.0)
+                    .unwrap(),
+                Side::Bid,
+                1_000,
+            )
+            .unwrap();
+
+        let sig = sdk
+            .client
+            .sign_send_instructions(vec![limit_order_ix], vec![])
+            .await
+            .unwrap();
+
+        println!(
+            "Order {} tx link: https://beta.solscan.io/tx/{}?cluster=devnet",
+            i + 1,
+            sig
+        );
+    }
+}
+
+// Only needed for devnet testing
+pub async fn create_airdrop_spl_ixs(
+    sdk_client: &SDKClient,
+    market_pubkey: &Pubkey,
+    recipient_pubkey: &Pubkey,
+) -> Option<Vec<Instruction>> {
+    // Get base and quote mints from market metadata
+    let market_metadata = sdk_client.get_market_metadata(market_pubkey).await.ok()?;
+    let base_mint = market_metadata.base_mint;
+    let quote_mint = market_metadata.quote_mint;
+
+    let mint_accounts = sdk_client
+        .client
+        .get_multiple_accounts(&[base_mint, quote_mint])
+        .await
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<Account>>();
+
+    let base_mint_account = Mint::unpack(&mint_accounts[0].data).unwrap();
+
+    let quote_mint_account = Mint::unpack(&mint_accounts[1].data).unwrap();
+
+    let base_mint_authority = base_mint_account.mint_authority.unwrap();
+    let quote_mint_authority = quote_mint_account.mint_authority.unwrap();
+
+    let mint_authority_accounts = sdk_client
+        .client
+        .get_multiple_accounts(&[base_mint_authority, quote_mint_authority])
+        .await
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<Account>>();
+
+    // If either the base or quote mint authority accounts (PDAs) are not owned by the devnet token faucet program, abort minting
+    if mint_authority_accounts[0].owner != generic_token_faucet::id()
+        || mint_authority_accounts[1].owner != generic_token_faucet::id()
+    {
+        return None;
+    }
+
+    // Get or create the ATA for the recipient. If doesn't exist, create token account
+    let mut instructions = vec![];
+
+    let recipient_ata_base =
+        spl_associated_token_account::get_associated_token_address(recipient_pubkey, &base_mint);
+
+    let recipient_ata_quote =
+        spl_associated_token_account::get_associated_token_address(recipient_pubkey, &quote_mint);
+
+    let recipient_ata_accounts = sdk_client
+        .client
+        .get_multiple_accounts(&[recipient_ata_base, recipient_ata_quote])
+        .await
+        .unwrap();
+
+    if recipient_ata_accounts[0].is_none() {
+        println!("Error retrieving base ATA. Creating base ATA");
+        instructions.push(create_associated_token_account(
+            &sdk_client.client.payer.pubkey(),
+            recipient_pubkey,
+            &base_mint,
+            &spl_token::id(),
+        ))
+    };
+
+    if recipient_ata_accounts[1].is_none() {
+        println!("Error retrieving quote ATA. Creating quote ATA");
+        instructions.push(create_associated_token_account(
+            &sdk_client.client.payer.pubkey(),
+            recipient_pubkey,
+            &quote_mint,
+            &spl_token::id(),
+        ))
+    };
+
+    // Finally, mint the base and quote tokens to the recipient. The recipient's ATAs will be automatically derived.
+    instructions.push(generic_token_faucet::airdrop_spl_with_mint_pdas_ix(
+        &generic_token_faucet::id(),
+        &base_mint,
+        &base_mint_authority,
+        recipient_pubkey,
+        (5000.0 * 1e9) as u64,
+    ));
+
+    instructions.push(generic_token_faucet::airdrop_spl_with_mint_pdas_ix(
+        &generic_token_faucet::id(),
+        &quote_mint,
+        &quote_mint_authority,
+        recipient_pubkey,
+        (500000.0 * 1e6) as u64,
+    ));
+
+    Some(instructions)
+}

--- a/rust/examples/src/bin/sample.rs
+++ b/rust/examples/src/bin/sample.rs
@@ -105,7 +105,7 @@ async fn main() -> anyhow::Result<()> {
             market_pubkey, header.quote_params.mint_key, header.base_params.mint_key
         );
 
-        if header.base_params.mint_key == devnet_token_faucet::get_mint_address("SOL")
+        if header.base_params.mint_key == generic_token_faucet::get_mint_address("SOL")
             || header.base_params.mint_key == spl_token::native_mint::id()
         {
             sol_usdc_market = Some(market_pubkey);

--- a/rust/examples/src/bin/simple_market_maker.rs
+++ b/rust/examples/src/bin/simple_market_maker.rs
@@ -1,0 +1,335 @@
+use anyhow::anyhow;
+use phoenix::state::Side;
+use solana_program::{clock::Clock, sysvar};
+use solana_sdk::{account::Account, signature::Signature};
+use spl_token::state::Mint;
+use std::str::FromStr;
+
+use clap::Parser;
+use phoenix_sdk::{order_packet_template::LimitOrderTemplate, sdk_client::SDKClient};
+use solana_cli_config::{Config, CONFIG_FILE};
+#[allow(unused_imports)]
+use solana_sdk::{
+    instruction::Instruction,
+    program_pack::Pack,
+    pubkey::Pubkey,
+    signature::{read_keypair_file, Keypair},
+    signer::Signer,
+};
+use spl_associated_token_account::instruction::create_associated_token_account;
+
+// Command-line arguments to parameterize the market maker.
+#[derive(Parser)]
+struct Args {
+    /// Optionally, use your own RPC endpoint by passing into the -u flag.
+    #[clap(short, long)]
+    url: Option<String>,
+
+    #[clap(short, long)]
+    market: Pubkey,
+
+    // The ticker is used to pull the price from the Coinbase API, and therefore should conform to the Coinbase ticker format.
+    /// Note that for all USDC quoted markets, the price feed should use "USD" instead of "USDC".
+    #[clap(short, long, default_value = "SOL-USD")]
+    ticker: String,
+
+    /// Optionally include your keypair path. Defaults to your Solana CLI config file.
+    #[clap(short, long)]
+    keypair_path: Option<String>,
+
+    #[clap(long, default_value = "2000")]
+    quote_refresh_frequency_in_ms: u64,
+
+    #[clap(long, default_value = "5")]
+    quote_edge_bps: u64,
+
+    #[clap(long, default_value = "250.0")]
+    quote_size_in_quote_units: f64,
+
+    #[clap(long, default_value = "10")]
+    order_lifetime_in_seconds: i64,
+}
+
+pub fn get_payer_keypair_from_path(path: &str) -> anyhow::Result<Keypair> {
+    read_keypair_file(&*shellexpand::tilde(path)).map_err(|e| anyhow!(e.to_string()))
+}
+
+pub fn get_network(network_str: &str) -> &str {
+    match network_str {
+        "devnet" | "dev" | "d" => "https://api.devnet.solana.com",
+        "mainnet" | "main" | "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
+        "localnet" | "localhost" | "l" | "local" => "http://localhost:8899",
+        _ => network_str,
+    }
+}
+
+// This script runs a simple market maker, which provides limit order bids and asks, on a given phoenix market.
+// To run this simple market maker example, use the following command from the examples directory: `cargo run --bin simple_market_maker -- -m CS2H8nbAVVEUHWPF5extCSymqheQdkd4d7thik6eet9N`
+// To run this example with your own RPC endpoint, use the following command from the examples directory:
+// `cargo run --bin simple_market_maker -- -m CS2H8nbAVVEUHWPF5extCSymqheQdkd4d7thik6eet9N -u $YOUR_DEVNET_RPC_ENDPOINT`
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Connect to the solana network and create a Phoenix Client with your trader keypair and the market pubkey.
+    let args = Args::parse();
+    let config = match CONFIG_FILE.as_ref() {
+        Some(config_file) => Config::load(config_file).unwrap_or_else(|_| {
+            println!("Failed to load config file: {}", config_file);
+            Config::default()
+        }),
+        None => Config::default(),
+    };
+    let trader = get_payer_keypair_from_path(&args.keypair_path.unwrap_or(config.keypair_path))?;
+    let network_url = &get_network(&args.url.unwrap_or(config.json_rpc_url)).to_string();
+
+    let mut sdk = SDKClient::new(&trader, network_url).await?;
+    let market = args.market;
+    sdk.add_market(&market).await?;
+
+    // To test on devnet, (i) airdrop devnet SOL to the trader account, and (ii) airdrop tokens for the market's base and quote tokens.
+    // These instructions only work on devnet.
+    // (i) airdrop devnet SOL to the trader account. This step may not be needed if your trader keypair (from the above file_path) already has devnet SOL.
+    // Below is an example of how to airdrop devnet SOL to the trader account. Commented out here because this method fails frequently on devnet.
+    // Ensure that your trader keypair has devnet SOL to execute transactions.
+    // sdk.client
+    //     .request_airdrop(&trader.pubkey(), 1_000_000_000)
+    //     .await
+    //     .unwrap();
+
+    // (ii) Airdrop tokens for the base and quote tokens for the supplied market, used for testing trades.
+    // Uses the generic-token-faucet (https://github.com/Ellipsis-Labs/generic-token-faucet).
+    let instructions = create_airdrop_spl_ixs(&sdk, &market, &trader.pubkey())
+        .await
+        .unwrap();
+    let setup_tx = sdk
+        .client
+        .sign_send_instructions(instructions, vec![])
+        .await
+        .unwrap();
+    println!(
+        "Setup tx: https://beta.solscan.io/tx/{}?cluster=devnet",
+        setup_tx
+    );
+
+    // To place limit orders on Phoenix, you need to ensure that you have associated token accounts for the base and quote tokens, and that you have a seat on the market.
+    // This method checks these requirements and returns instructions to create the necessary accounts, if needed:
+    // - Creation of associated token accounts for base and quote tokens, if needed.
+    // - Claiming of the market's seat, if needed.
+    // - Evicting a seat on the market if the market trader state is full.
+    // Once you have a seat, you can freely place orders without needing to claim a seat before every order.
+    // Note: If the market's trader state is full and your seat is not in use (you do not have locked funds), your seat may be evicted, causing future limit orders to fail.
+    // In that case, simply request a new seat with the SDK method `sdk.create_claim_seat_ix_if_needed`.
+    let maker_setup_instructions = sdk.get_maker_setup_instructions_for_market(&market).await?;
+    sdk.client
+        .sign_send_instructions(maker_setup_instructions, vec![])
+        .await
+        .unwrap();
+
+    loop {
+        match cancel_and_place_quotes(
+            &sdk,
+            &args.market,
+            &args.ticker.to_uppercase(),
+            args.quote_size_in_quote_units,
+            args.quote_edge_bps,
+            args.order_lifetime_in_seconds,
+        )
+        .await
+        {
+            Ok(sig) => println!("Tx Link: https://beta.solscan.io/tx/{}?cluster=devnet", sig),
+            Err(e) => println!("Encountered error: {}", e),
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(
+            args.quote_refresh_frequency_in_ms,
+        ))
+        .await;
+    }
+}
+
+async fn cancel_and_place_quotes(
+    sdk: &SDKClient,
+    market: &Pubkey,
+    ticker: &str,
+    quote_size_in_quote_units: f64,
+    quote_edge_bps: u64,
+    order_lifetime_in_seconds: i64,
+) -> anyhow::Result<Signature> {
+    let cancel_all_ix = sdk.get_cancel_all_ix(market)?;
+    let mut ixs = vec![cancel_all_ix];
+
+    let fair_price = {
+        let response = reqwest::get(format!(
+            "https://api.coinbase.com/v2/prices/{}/spot",
+            ticker
+        ))
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+
+        f64::from_str(response["data"]["amount"].as_str().unwrap())?
+    };
+
+    // place a bid and ask at the fair price +/- edge
+    let bid_price = fair_price * (1.0 - quote_edge_bps as f64 / 10000.0);
+    let ask_price = fair_price * (1.0 + quote_edge_bps as f64 / 10000.0);
+
+    if bid_price == 0.0 || ask_price == 0.0 {
+        println!("Bid or ask price is 0.0, skipping order placement, cancelling orders");
+        let txid = sdk.client.sign_send_instructions(ixs, vec![]).await?;
+        return Ok(txid);
+    }
+
+    let bid_size = quote_size_in_quote_units / bid_price;
+    let ask_size = quote_size_in_quote_units / ask_price;
+    // Get the current chain time for to specify an order expiration time (time in force orders).
+    let clock_account_data = sdk.client.get_account_data(&sysvar::clock::id()).await?;
+
+    let clock: Clock = bincode::deserialize(&clock_account_data)
+        .map_err(|_| anyhow::Error::msg("Error deserializing clock"))?;
+
+    // Create a LimitOrderTemplate for the bid and ask orders.
+    // the LimitOrderTemplate allows you to specify the price and size in commonly understood units:
+    // price is the floating point price (units of USDC per unit of SOL for the SOL/USDC market), and size is in whole base units (units of SOL for the SOL/USDC market).
+    let bid_limit_order_template = LimitOrderTemplate {
+        side: Side::Bid,
+        price_as_float: bid_price,
+        size_in_base_units: bid_size,
+        self_trade_behavior: phoenix::state::SelfTradeBehavior::CancelProvide,
+        match_limit: None,
+        client_order_id: 0,
+        use_only_deposited_funds: false,
+        last_valid_slot: None,
+        last_valid_unix_timestamp_in_seconds: Some(
+            (clock.unix_timestamp + order_lifetime_in_seconds) as u64,
+        ),
+    };
+
+    let ask_limit_order_template = LimitOrderTemplate {
+        side: Side::Ask,
+        price_as_float: ask_price,
+        size_in_base_units: ask_size,
+        self_trade_behavior: phoenix::state::SelfTradeBehavior::CancelProvide,
+        match_limit: None,
+        client_order_id: 0,
+        use_only_deposited_funds: false,
+        last_valid_slot: None,
+        last_valid_unix_timestamp_in_seconds: Some(
+            (clock.unix_timestamp + order_lifetime_in_seconds) as u64,
+        ),
+    };
+
+    println!("Placing bid for size {}, price {}", bid_size, bid_price);
+    println!("Placing ask for size {}, price {}", ask_price, ask_size);
+
+    let market_metadata = sdk.get_market_metadata(market).await?;
+    // Use an SDK-provided helper function to convert the limit order template into a limit order instruction, which contains Phoenix-specific units that the orderbook uses.
+    let bid_ix =
+        sdk.get_limit_order_ix_from_template(market, &market_metadata, &bid_limit_order_template)?;
+
+    let ask_ix =
+        sdk.get_limit_order_ix_from_template(market, &market_metadata, &ask_limit_order_template)?;
+
+    ixs.push(bid_ix);
+    ixs.push(ask_ix);
+
+    let txid = sdk.client.sign_send_instructions(ixs, vec![]).await?;
+    Ok(txid)
+}
+
+// Only needed for devnet testing
+pub async fn create_airdrop_spl_ixs(
+    sdk_client: &SDKClient,
+    market_pubkey: &Pubkey,
+    recipient_pubkey: &Pubkey,
+) -> Option<Vec<Instruction>> {
+    // Get base and quote mints from market metadata
+    let market_metadata = sdk_client.get_market_metadata(market_pubkey).await.ok()?;
+    let base_mint = market_metadata.base_mint;
+    let quote_mint = market_metadata.quote_mint;
+
+    let mint_accounts = sdk_client
+        .client
+        .get_multiple_accounts(&[base_mint, quote_mint])
+        .await
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<Account>>();
+
+    let base_mint_account = Mint::unpack(&mint_accounts[0].data).unwrap();
+
+    let quote_mint_account = Mint::unpack(&mint_accounts[1].data).unwrap();
+
+    let base_mint_authority = base_mint_account.mint_authority.unwrap();
+    let quote_mint_authority = quote_mint_account.mint_authority.unwrap();
+
+    let mint_authority_accounts = sdk_client
+        .client
+        .get_multiple_accounts(&[base_mint_authority, quote_mint_authority])
+        .await
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<Account>>();
+
+    // If either the base or quote mint authority accounts (PDAs) are not owned by the devnet token faucet program, abort minting
+    if mint_authority_accounts[0].owner != generic_token_faucet::id()
+        || mint_authority_accounts[1].owner != generic_token_faucet::id()
+    {
+        return None;
+    }
+
+    // Get or create the ATA for the recipient. If doesn't exist, create token account
+    let mut instructions = vec![];
+
+    let recipient_ata_base =
+        spl_associated_token_account::get_associated_token_address(recipient_pubkey, &base_mint);
+
+    let recipient_ata_quote =
+        spl_associated_token_account::get_associated_token_address(recipient_pubkey, &quote_mint);
+
+    let recipient_ata_accounts = sdk_client
+        .client
+        .get_multiple_accounts(&[recipient_ata_base, recipient_ata_quote])
+        .await
+        .unwrap();
+
+    if recipient_ata_accounts[0].is_none() {
+        println!("Error retrieving base ATA. Creating base ATA");
+        instructions.push(create_associated_token_account(
+            &sdk_client.client.payer.pubkey(),
+            recipient_pubkey,
+            &base_mint,
+            &spl_token::id(),
+        ))
+    };
+
+    if recipient_ata_accounts[1].is_none() {
+        println!("Error retrieving quote ATA. Creating quote ATA");
+        instructions.push(create_associated_token_account(
+            &sdk_client.client.payer.pubkey(),
+            recipient_pubkey,
+            &quote_mint,
+            &spl_token::id(),
+        ))
+    };
+
+    // Finally, mint the base and quote tokens to the recipient. The recipient's ATAs will be automatically derived.
+    instructions.push(generic_token_faucet::airdrop_spl_with_mint_pdas_ix(
+        &generic_token_faucet::id(),
+        &base_mint,
+        &base_mint_authority,
+        recipient_pubkey,
+        (5000.0 * 1e9) as u64,
+    ));
+
+    instructions.push(generic_token_faucet::airdrop_spl_with_mint_pdas_ix(
+        &generic_token_faucet::id(),
+        &quote_mint,
+        &quote_mint_authority,
+        recipient_pubkey,
+        (500000.0 * 1e6) as u64,
+    ));
+
+    Some(instructions)
+}

--- a/rust/phoenix-sdk-core/Cargo.toml
+++ b/rust/phoenix-sdk-core/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "phoenix-sdk-core"
-version = "0.3.8"
+version = "0.4.0"
 description = "Core SDK for interacting with the Phoenix program"
 edition = "2021"
 license = "MIT"

--- a/rust/phoenix-sdk/Cargo.toml
+++ b/rust/phoenix-sdk/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "phoenix-sdk"
-version = "0.3.8"
+version = "0.4.0"
 description = "SDK for interacting with the Phoenix program"
 edition = "2021"
 license = "MIT"
@@ -29,7 +29,7 @@ rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }
 bytemuck = { workspace = true }
 itertools = "0.10.5"
-phoenix-sdk-core = { version = "0.3.8", path = "../phoenix-sdk-core" }
+phoenix-sdk-core = { version = "0.4.0", path = "../phoenix-sdk-core" }
 serde = { workspace = true }
 spl-associated-token-account = { workspace = true }
 phoenix-seat-manager = { workspace = true }

--- a/rust/phoenix-sdk/Cargo.toml
+++ b/rust/phoenix-sdk/Cargo.toml
@@ -31,3 +31,5 @@ bytemuck = { workspace = true }
 itertools = "0.10.5"
 phoenix-sdk-core = { version = "0.3.8", path = "../phoenix-sdk-core" }
 serde = { workspace = true }
+spl-associated-token-account = { workspace = true }
+phoenix-seat-manager = { workspace = true }

--- a/rust/phoenix-sdk/src/lib.rs
+++ b/rust/phoenix-sdk/src/lib.rs
@@ -1,2 +1,4 @@
 pub use phoenix_sdk_core::orderbook;
+pub mod order_packet_template;
 pub mod sdk_client;
+pub mod utils;

--- a/rust/phoenix-sdk/src/order_packet_template.rs
+++ b/rust/phoenix-sdk/src/order_packet_template.rs
@@ -1,0 +1,125 @@
+use phoenix::state::{SelfTradeBehavior, Side};
+
+/// LimitOrderTemplate is a helper type for creating a limit order.
+/// The template allows you to specify the price and size in commonly understood units:
+/// price is the floating point price (units of USDC per unit of SOL for the SOL/USDC market), and size is in whole base units (units of SOL for the SOL/USDC market).
+/// The SDK can then convert this to a limit order instruction, ready to be sent.
+pub struct LimitOrderTemplate {
+    // The side for the order, a Side::Bid or a Side::Ask.
+    pub side: Side,
+
+    /// The price of the order, as the commonly understood exchange price (the number of quote units to exchange for one base unit), as a floating point number.
+    pub price_as_float: f64,
+
+    /// Total number of base units, as a floating point number, to place on the book or fill at a better price.
+    pub size_in_base_units: f64,
+
+    /// How the matching engine should handle a self trade.
+    pub self_trade_behavior: SelfTradeBehavior,
+
+    /// Number of orders to match against. If this is `None` there is no limit.
+    pub match_limit: Option<u64>,
+
+    /// Client order id used to identify the order in the response to the client.
+    pub client_order_id: u128,
+
+    /// Flag for whether or not the order should only use funds that are already in the account.
+    /// Using only deposited funds will allow the trader to pass in fewer accounts per instruction and
+    /// save transaction space as well as compute.
+    pub use_only_deposited_funds: bool,
+
+    /// If this is set, the order will be invalid after the specified slot.
+    pub last_valid_slot: Option<u64>,
+
+    /// If this is set, the order will be invalid after the specified unix timestamp.
+    pub last_valid_unix_timestamp_in_seconds: Option<u64>,
+}
+
+/// PostOnlyOrderTemplate is a helper type for creating a post-only order, which will never be matched against existing orders.
+/// The template allows you to specify the price and size in commonly understood units:
+/// price is the floating point price (units of USDC per unit of SOL for the SOL/USDC market), and size is in whole base units (units of SOL for the SOL/USDC market).
+/// The SDK can then convert this to a post-only order instruction, ready to be sent.
+pub struct PostOnlyOrderTemplate {
+    // The side for the order, a Side::Bid or a Side::Ask.
+    pub side: Side,
+
+    /// The price of the order, as the commonly understood exchange price (the number of quote units to exchange for one base unit), as a floating point number.
+    pub price_as_float: f64,
+
+    /// Total number of base units, as a floating point number, to place on the book or fill at a better price.
+    pub size_in_base_units: f64,
+
+    /// Client order id used to identify the order in the response to the client.
+    pub client_order_id: u128,
+
+    /// Flag for whether or not to reject the order if it would immediately match or amend it to the best non-crossing price.
+    /// Default value is true.
+    pub reject_post_only: bool,
+
+    /// Flag for whether or not the order should only use funds that are already in the account.
+    /// Using only deposited funds will allow the trader to pass in fewer accounts per instruction and
+    /// save transaction space as well as compute.
+    pub use_only_deposited_funds: bool,
+
+    /// If this is set, the order will be invalid after the specified slot.
+    pub last_valid_slot: Option<u64>,
+
+    /// If this is set, the order will be invalid after the specified unix timestamp.
+    pub last_valid_unix_timestamp_in_seconds: Option<u64>,
+}
+
+/// ImmediateOrCancelOrderTemplate is a helper type for creating an immediate or cancel order.
+/// The template allows you to specify the price and size in commonly understood units:
+/// price is the floating point price (units of USDC per unit of SOL for the SOL/USDC market), and size is in whole base units (units of SOL for the SOL/USDC market).
+/// The SDK can then convert this to a limit order instruction, ready to be sent.
+///
+/// Immediate-or-cancel orders will be matched against existing resting orders.
+/// If the order matches fewer than `min_lots` lots, it will be cancelled.
+///
+/// Fill or Kill (FOK) orders are a subset of Immediate or Cancel (IOC) orders where either
+/// the `num_base_lots` is equal to the `min_base_lots_to_fill` of the order, or the `num_quote_lots` is
+/// equal to the `min_quote_lots_to_fill` of the order.
+pub struct ImmediateOrCancelOrderTemplate {
+    // The side for the order, a Side::Bid or a Side::Ask.
+    pub side: Side,
+
+    /// The most aggressive price an order can be matched at. If this value is None, then the order
+    /// is treated as a market order.
+    pub price_as_float: Option<f64>,
+
+    /// The number of base units to fill against the order book. Either this parameter or the `num_quote_units`
+    /// parameter must be set to a nonzero value.
+    pub size_in_base_units: f64,
+
+    /// The number of quote units to fill against the order book. Either this parameter or the `num_base_units`
+    /// parameter must be set to a nonzero value.
+    pub size_in_quote_units: f64,
+
+    /// The minimum number of base units to fill against the order book. If the order does not fill
+    /// this many base lots, it will be voided.
+    pub min_base_units_to_fill: f64,
+
+    /// The minimum number of quote units to fill against the order book. If the order does not fill
+    /// this many quote lots, it will be voided.
+    pub min_quote_units_to_fill: f64,
+
+    /// How the matching engine should handle a self trade.
+    pub self_trade_behavior: SelfTradeBehavior,
+
+    /// Number of orders to match against. If set to `None`, there is no limit.
+    pub match_limit: Option<u64>,
+
+    /// Client order id used to identify the order in the response to the client.
+    pub client_order_id: u128,
+
+    /// Flag for whether or not the order should only use funds that are already in the account.
+    /// Using only deposited funds will allow the trader to pass in less accounts per instruction and
+    /// save transaction space as well as compute. This is only for traders who have a seat.
+    pub use_only_deposited_funds: bool,
+
+    /// If this is set, the order will be invalid after the specified slot.
+    pub last_valid_slot: Option<u64>,
+
+    /// If this is set, the order will be invalid after the specified unix timestamp.
+    pub last_valid_unix_timestamp_in_seconds: Option<u64>,
+}

--- a/rust/phoenix-sdk/src/utils.rs
+++ b/rust/phoenix-sdk/src/utils.rs
@@ -1,0 +1,125 @@
+use std::mem::size_of;
+
+use ellipsis_client::EllipsisClient;
+use phoenix::program::{
+    dispatch_market, get_seat_address, status::SeatApprovalStatus, MarketHeader, Seat,
+};
+use phoenix_seat_manager::{
+    get_seat_manager_address,
+    instruction_builders::{
+        create_claim_seat_instruction, create_evict_seat_instruction, EvictTraderAccountBackup,
+    },
+    seat_manager::SeatManager,
+};
+use solana_program::{instruction::Instruction, pubkey::Pubkey};
+use spl_associated_token_account::{
+    get_associated_token_address, instruction::create_associated_token_account,
+};
+
+pub async fn create_ata_ix_if_needed(
+    client: &EllipsisClient,
+    payer: &Pubkey,
+    trader: &Pubkey,
+    mint: &Pubkey,
+) -> Vec<Instruction> {
+    let ata_address = get_associated_token_address(trader, mint);
+    let ata_account = client.get_account(&ata_address).await;
+
+    if let Ok(ata_account) = ata_account {
+        if !ata_account.data.is_empty() {
+            return vec![];
+        }
+    }
+    vec![create_associated_token_account(
+        payer,
+        trader,
+        mint,
+        &spl_token::ID,
+    )]
+}
+
+// Check if seat already exists, if not, create seat instruction.
+// Check if the market trader state is full, if so, find a seat to evict and add the evict instruction.
+pub async fn create_claim_seat_ix_if_needed(
+    client: &EllipsisClient,
+    market_pubkey: &Pubkey,
+    trader: &Pubkey,
+) -> anyhow::Result<Vec<Instruction>> {
+    let seat_address = get_seat_address(market_pubkey, trader).0;
+    let seat_account = client.get_account(&seat_address).await;
+
+    // If the seat is found, is initialized, and is already Approved, return early.
+    if let Ok(seat_account) = seat_account {
+        if !seat_account.data.is_empty() {
+            let seat_struct = bytemuck::from_bytes::<Seat>(seat_account.data.as_slice());
+            // If the seat account is found and is already approved, return early.
+            if SeatApprovalStatus::from(seat_struct.approval_status) == SeatApprovalStatus::Approved
+            {
+                return Ok(vec![]);
+            }
+        }
+    }
+
+    // If the seat is not found, or the seat data is empty, or the seat is not approved, check if eviction needs to be performed (if market trader state is full). Then create a claim seat instruction.
+    let mut instructions = vec![];
+    if let Ok(Some(evict_trader_ix)) = get_evictable_trader_ix(client, market_pubkey).await {
+        instructions.push(evict_trader_ix);
+    }
+    instructions.push(create_claim_seat_instruction(trader, market_pubkey));
+
+    Ok(instructions)
+}
+
+// Finds the first evictable trader without locked base or quote lots when the market state is full.
+pub async fn get_evictable_trader_ix(
+    client: &EllipsisClient,
+    market_pubkey: &Pubkey,
+) -> anyhow::Result<Option<Instruction>> {
+    let market_bytes = client.get_account_data(market_pubkey).await?;
+    let (header_bytes, market_bytes) = market_bytes.split_at(size_of::<MarketHeader>());
+    let market_header = bytemuck::try_from_bytes::<MarketHeader>(header_bytes)
+        .map_err(|e| anyhow::anyhow!("Error deserializing market header. Error: {:?}", e))?;
+
+    let market =
+        dispatch_market::load_with_dispatch(&market_header.market_size_params, market_bytes)?.inner;
+
+    let trader_tree = market.get_registered_traders();
+    let num_traders = trader_tree.len();
+    let max_traders = trader_tree.capacity();
+
+    let seat_manager_address = get_seat_manager_address(market_pubkey).0;
+    let seat_manager_account = client.get_account_data(&seat_manager_address).await?;
+    let seat_manager_struct =
+        bytemuck::try_from_bytes::<SeatManager>(seat_manager_account.as_slice()).map_err(|e| {
+            anyhow::anyhow!("Error deserializing seat manager data. Error: {:?}", e)
+        })?;
+
+    // If the market's trader state is full, evict a trader to make room for a new trader.
+    if num_traders == max_traders {
+        //Find a seat to evict (a trader with no locked base or quote lots) and evict trader.
+        for (trader_pubkey, trader_state) in trader_tree.iter() {
+            if trader_state.base_lots_locked == 0 && trader_state.quote_lots_locked == 0 {
+                // A DMM cannot be evicted directly. They must first be removed as a DMM. Skip DMMs in this search.
+                if seat_manager_struct.contains(trader_pubkey) {
+                    continue;
+                }
+                let evict_trader_state = EvictTraderAccountBackup {
+                    trader_pubkey: *trader_pubkey,
+                    base_token_account_backup: None,
+                    quote_token_account_backup: None,
+                };
+                return Ok(Some(create_evict_seat_instruction(
+                    market_pubkey,
+                    &market_header.base_params.mint_key,
+                    &market_header.quote_params.mint_key,
+                    trader_pubkey,
+                    vec![evict_trader_state],
+                )));
+            }
+        }
+        return Err(anyhow::anyhow!(
+            "Trader state is full but unable to find a trader with no locked lots to evict."
+        ));
+    };
+    Ok(None)
+}


### PR DESCRIPTION
+[TX signature](https://solana.fm/tx/2orwNxEXaAJosd54Fz7tiJAtGhKaNAAsYpacLRw2VcLCpzAwrW4fmu24pYUG2gsSbGog85G9nzN6fyv9b6TyD8ms?cluster=devnet-qn1
) from `place_order.rs` within examples that uses the new PLL helpers. 
Notes:
- default send post only and send limit order now uses the new maker instructions
- **UPDATE BEFORE MERGE** Cargo.toml of seat manager once the latter is public