### PR TITLE
Refactor SDK to minimize network calls and properly create interface boundaries

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-sdk"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-sdk-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "borsh 0.9.3",

--- a/rust/phoenix-sdk-core/Cargo.toml
+++ b/rust/phoenix-sdk-core/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "phoenix-sdk-core"
-version = "0.3.6"
+version = "0.3.7"
 description = "Core SDK for interacting with the Phoenix program"
 edition = "2021"
 license = "MIT"

--- a/rust/phoenix-sdk-core/src/sdk_client_core.rs
+++ b/rust/phoenix-sdk-core/src/sdk_client_core.rs
@@ -438,6 +438,14 @@ impl SDKClientCore {
             .ok_or_else(|| anyhow!("Market not found! Please load in the market first"))
             .map(|m| m.raw_base_units_per_base_lot())
     }
+
+    /// Given a market, returns the tick size in quote units per raw base unit
+    pub fn quote_units_per_raw_base_unit_per_tick(&self, market_key: &Pubkey) -> Result<f64> {
+        self.markets
+            .get(market_key)
+            .ok_or_else(|| anyhow!("Market not found! Please load in the market first"))
+            .map(|m| m.quote_units_per_raw_base_unit_per_tick())
+    }
 }
 
 impl SDKClientCore {

--- a/rust/phoenix-sdk-core/src/test_unit_conversion.rs
+++ b/rust/phoenix-sdk-core/src/test_unit_conversion.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use phoenix::state::Side;
+use phoenix::{program::MarketSizeParams, state::Side};
 use solana_program::pubkey::Pubkey;
 
 use crate::{
@@ -22,6 +22,8 @@ fn setup(market: &Pubkey) -> SDKClientCore {
         quote_decimals: 6,
         base_mint: Pubkey::new_unique(),
         quote_mint: Pubkey::new_unique(),
+        // Irrelevant for tests
+        market_size_params: MarketSizeParams::default(),
     };
     assert_eq!(
         meta.base_atoms_per_raw_base_unit * meta.raw_base_units_per_base_unit as u64
@@ -60,6 +62,8 @@ fn setup_with_raw_base_unit_multiplier(
         quote_decimals: 6,
         base_mint: Pubkey::new_unique(),
         quote_mint: Pubkey::new_unique(),
+        // Irrelevant for tests
+        market_size_params: MarketSizeParams::default(),
     };
     assert_eq!(
         meta.base_atoms_per_raw_base_unit * meta.raw_base_units_per_base_unit as u64

--- a/rust/phoenix-sdk/Cargo.toml
+++ b/rust/phoenix-sdk/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "phoenix-sdk"
-version = "0.3.6"
+version = "0.3.7"
 description = "SDK for interacting with the Phoenix program"
 edition = "2021"
 license = "MIT"
@@ -29,5 +29,5 @@ rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }
 bytemuck = { workspace = true }
 itertools = "0.10.5"
-phoenix-sdk-core = { version = "0.3.6", path = "../phoenix-sdk-core" }
+phoenix-sdk-core = { version = "0.3.7", path = "../phoenix-sdk-core" }
 serde = { workspace = true }

--- a/rust/phoenix-sdk/src/sdk_client.rs
+++ b/rust/phoenix-sdk/src/sdk_client.rs
@@ -279,6 +279,12 @@ impl SDKClient {
             .and_then(MarketMetadata::from_header)
     }
 
+    /// Fetches a market's metadata from the SDKClient's market cache. This cache must be
+    /// explicitly populated by calling `add_market` or `add_all_markets`.
+    ///
+    /// Because the market metadata is static, it is recommended to call `add_market` and
+    /// use this function when repeatedly looking up metadata to avoid making
+    /// additional RPC calls.
     pub fn get_market_metadata_from_cache(
         &self,
         market_key: &Pubkey,

--- a/rust/phoenix-sdk/src/sdk_client.rs
+++ b/rust/phoenix-sdk/src/sdk_client.rs
@@ -61,6 +61,7 @@ impl DerefMut for SDKClient {
     }
 }
 
+/// Constuctor functions that create a new SDKClient
 impl SDKClient {
     /// Create a new SDKClient from an EllipsisClient.
     /// This does not have any markets added to it. You must call `add_market` or `add_all_markets` to
@@ -192,7 +193,10 @@ impl SDKClient {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(Self::new_with_market_keys(market_keys, payer, url))
     }
+}
 
+/// Mutable functions that modify the internal state of the SDKClient
+impl SDKClient {
     /// Load in all known markets from a pre-defined config file located in the SDK github.
     pub async fn add_all_markets(&mut self) -> Result<()> {
         let config_url = "https://raw.githubusercontent.com/Ellipsis-Labs/phoenix-sdk/master/typescript/phoenix-sdk/config.json";
@@ -233,6 +237,7 @@ impl SDKClient {
         rt.block_on(self.add_all_markets())
     }
 
+    /// This function adds the metadata for a market to the SDKClient's market cache.
     pub async fn add_market(&mut self, market_key: &Pubkey) -> anyhow::Result<()> {
         let market_metadata = self.get_market_metadata(market_key).await?;
         self.markets.insert(*market_key, market_metadata);
@@ -252,15 +257,47 @@ impl SDKClient {
     pub fn get_trader(&self) -> Pubkey {
         self.trader
     }
+}
+
+/// Getter functions that make asynchronous calls via a Solana RPC connection to fetch state and events from Phoenix.
+impl SDKClient {
+    pub async fn get_market_metadata(&self, market_key: &Pubkey) -> Result<MarketMetadata> {
+        match self.markets.get(market_key) {
+            Some(metadata) => return Ok(metadata.clone()),
+            None => {
+                let market_account_data = (self.client.get_account_data(market_key))
+                    .await
+                    .map_err(|_| anyhow!("Failed to find market account"))?;
+                self.get_market_metadata_from_header_bytes(&market_account_data)
+            }
+        }
+    }
+
+    fn get_market_metadata_from_header_bytes(&self, header_bytes: &[u8]) -> Result<MarketMetadata> {
+        bytemuck::try_from_bytes(header_bytes)
+            .map_err(|_| anyhow!("Failed to deserialize market header"))
+            .and_then(MarketMetadata::from_header)
+    }
+
+    pub fn get_market_metadata_from_cache(
+        &self,
+        market_key: &Pubkey,
+    ) -> anyhow::Result<&MarketMetadata> {
+        match self.markets.get(market_key) {
+            Some(metadata) => return Ok(metadata),
+            None => Err(anyhow!(
+                "Market metadata not found in cache. Try calling add_market first."
+            )),
+        }
+    }
 
     pub async fn get_market_ladder(&self, market_key: &Pubkey, levels: u64) -> Result<Ladder> {
         let market_account_data = (self.client.get_account_data(market_key))
             .await
             .map_err(|_| anyhow!("Failed to get market account data"))?;
         let (header_bytes, bytes) = market_account_data.split_at(size_of::<MarketHeader>());
-        let header: &MarketHeader =
-            bytemuck::try_from_bytes(header_bytes).expect("Failed to deserialize market header");
-        let market = load_with_dispatch(&header.market_size_params, bytes)
+        let meta = self.get_market_metadata_from_header_bytes(header_bytes)?;
+        let market = load_with_dispatch(&meta.market_size_params, bytes)
             .map_err(|_| anyhow!("Market configuration not found"))?
             .inner;
 
@@ -279,36 +316,28 @@ impl SDKClient {
         let market_account_data = (self.client.get_account_data(market_key))
             .await
             .unwrap_or_default();
-        let default = Orderbook::<FIFOOrderId, PhoenixOrder> {
+        let default_orderbook = Orderbook::<FIFOOrderId, PhoenixOrder> {
             raw_base_units_per_base_lot: 0.0,
             quote_units_per_raw_base_unit_per_tick: 0.0,
             bids: BTreeMap::new(),
             asks: BTreeMap::new(),
         };
         if market_account_data.is_empty() {
-            return Ok(default);
+            return Ok(default_orderbook);
         }
         let (header_bytes, bytes) = market_account_data.split_at(size_of::<MarketHeader>());
-        let meta = self.get_market_metadata_from_cache(market_key)?;
-        let raw_base_units_per_base_lot =
-            meta.base_atoms_per_base_lot as f64 / meta.base_atoms_per_raw_base_unit as f64;
-        let quote_units_per_raw_base_unit_per_tick = meta.tick_size_in_quote_atoms_per_base_unit
-            as f64
-            / (meta.quote_atoms_per_quote_unit as f64 * meta.raw_base_units_per_base_unit as f64);
-        Ok(bytemuck::try_from_bytes::<MarketHeader>(header_bytes)
-            .ok()
-            .map(|header| {
-                load_with_dispatch(&header.market_size_params, bytes)
-                    .map(|market| {
-                        Orderbook::from_market(
-                            market.inner,
-                            raw_base_units_per_base_lot,
-                            quote_units_per_raw_base_unit_per_tick,
-                        )
-                    })
-                    .unwrap_or_else(|_| default.clone())
+        let meta = self.get_market_metadata_from_header_bytes(header_bytes)?;
+        let raw_base_units_per_base_lot = meta.raw_base_units_per_base_lot();
+        let quote_units_per_raw_base_unit_per_tick = meta.quote_units_per_raw_base_unit_per_tick();
+        Ok(load_with_dispatch(&meta.market_size_params, bytes)
+            .map(|market| {
+                Orderbook::from_market(
+                    market.inner,
+                    raw_base_units_per_base_lot,
+                    quote_units_per_raw_base_unit_per_tick,
+                )
             })
-            .unwrap_or(default))
+            .unwrap_or_else(|_| default_orderbook.clone()))
     }
 
     pub async fn get_market_orderbook_sync(
@@ -328,9 +357,8 @@ impl SDKClient {
             Err(_) => return Ok(BTreeMap::new()),
         };
         let (header_bytes, bytes) = market_account_data.split_at(size_of::<MarketHeader>());
-        let header = bytemuck::try_from_bytes::<MarketHeader>(header_bytes)
-            .map_err(|_| anyhow!("Failed to deserialize market header"))?;
-        let market = load_with_dispatch(&header.market_size_params, bytes)
+        let meta = self.get_market_metadata_from_header_bytes(header_bytes)?;
+        let market = load_with_dispatch(&meta.market_size_params, bytes)
             .map_err(|_| anyhow!("Market configuration not found"))?
             .inner;
 
@@ -365,22 +393,14 @@ impl SDKClient {
             }
         };
         let (header_bytes, bytes) = market_account_data.split_at(size_of::<MarketHeader>());
-        let header = bytemuck::try_from_bytes::<MarketHeader>(header_bytes)
-            .expect("Failed to deserialize market header");
-        let market = load_with_dispatch(&header.market_size_params, bytes)
-            .expect("Market configuration not found")
+        let meta = self.get_market_metadata_from_header_bytes(header_bytes)?;
+        let market = load_with_dispatch(&meta.market_size_params, bytes)
+            .map_err(|_| anyhow!("Market configuration not found"))?
             .inner;
-
-        let meta = self.get_market_metadata_from_cache(market_key)?;
-        let raw_base_units_per_base_lot =
-            meta.base_atoms_per_base_lot as f64 / meta.base_atoms_per_raw_base_unit as f64;
-        let quote_units_per_raw_base_unit_per_tick = meta.tick_size_in_quote_atoms_per_base_unit
-            as f64
-            / (meta.quote_atoms_per_quote_unit as f64 * meta.raw_base_units_per_base_unit as f64);
         let orderbook = Orderbook::from_market(
             market,
-            raw_base_units_per_base_lot,
-            quote_units_per_raw_base_unit_per_tick,
+            meta.raw_base_units_per_base_lot(),
+            meta.quote_units_per_raw_base_unit_per_tick(),
         );
 
         let traders = market
@@ -390,34 +410,6 @@ impl SDKClient {
             .collect();
 
         Ok(MarketState { orderbook, traders })
-    }
-
-    pub async fn get_market_metadata(&self, market_key: &Pubkey) -> Result<MarketMetadata> {
-        match self.markets.get(market_key) {
-            Some(metadata) => return Ok(metadata.clone()),
-            None => {
-                let market_account_data = (self.client.get_account_data(market_key))
-                    .await
-                    .map_err(|_| anyhow!("Failed to find market account"))?;
-
-                let (header_bytes, _) = market_account_data.split_at(size_of::<MarketHeader>());
-                let header = bytemuck::try_from_bytes::<MarketHeader>(header_bytes)
-                    .map_err(|_| anyhow!("Failed to deserialize market header"))?;
-                MarketMetadata::from_header(&header)
-            }
-        }
-    }
-
-    pub fn get_market_metadata_from_cache(
-        &self,
-        market_key: &Pubkey,
-    ) -> anyhow::Result<&MarketMetadata> {
-        match self.markets.get(market_key) {
-            Some(metadata) => return Ok(metadata),
-            None => Err(anyhow!(
-                "Market metadata not found in cache. Try calling add_market first."
-            )),
-        }
     }
 
     pub async fn parse_events_from_transaction(
@@ -704,7 +696,10 @@ impl SDKClient {
 
         (fills, places)
     }
+}
 
+/// Functions for sending transactions that interact with the Phoenix program
+impl SDKClient {
     pub async fn send_ioc(
         &self,
         market_key: &Pubkey,


### PR DESCRIPTION
Given that we're in SDK land, I think that the default should be to use the MarketMetadata object as opposed to the MarketHeader object. There were previously a lot of areas where we seem to be indecisive on which object to use when grabbing market metadata, and now I think every case is disambiguated.

There should be 0 interface changes that arise from this PR.


Changes:
- Add unit conversion helper to MarketMetadata struct
- Still enable SDK users to look up conversion by market
- No longer force users to call add market to a mutable SDK prior to using functions like `get_market_orderbook`

Notes:
- The code now makes a few more copies than before (need to load MarketMetadata into a struct). This itself is super small and should have 0 impact on code perf
- I added back helper conversions that were removed from a previous PR