### PR TITLE
Add grpc example and slight refactor to sdk

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -390,6 +390,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +438,74 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "autotools"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "axum"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.8",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
 
 [[package]]
 name = "base64"
@@ -1336,13 +1426,14 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "ellipsis-client"
-version = "0.1.15"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92efab2c0f9b9cb5b40190256544883b6bb02f90cf6301bfffecf1479bf74b5a"
+checksum = "7f13b3e24cd9f9468802b0fabc9e0c06d38360aa6e8f4851597ae8dfa59d941b"
 dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
+ "backoff",
  "base64 0.13.1",
  "bincode",
  "borsh 0.9.3",
@@ -1368,6 +1459,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-serde",
+ "yellowstone-grpc-client",
+ "yellowstone-grpc-proto",
 ]
 
 [[package]]
@@ -1519,6 +1612,12 @@ dependencies = [
  "redox_syscall",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1946,6 +2045,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2477,12 @@ dependencies = [
  "quote 1.0.23",
  "syn 1.0.107",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -2726,8 +2849,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phoenix-sdk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2757,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-sdk-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "borsh 0.9.3",
@@ -2891,6 +3024,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +3105,69 @@ dependencies = [
  "syn 1.0.107",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.107",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
 ]
 
 [[package]]
@@ -4735,6 +4941,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4953,6 +5165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5098,6 +5320,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.13.1",
+ "bytes",
+ "flate2",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "rustls-native-certs",
+ "rustls-pemfile 1.0.2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util 0.7.7",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+dependencies = [
+ "prettyplease",
+ "proc-macro2 1.0.51",
+ "prost-build",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.7",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,6 +5432,16 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -5487,6 +5794,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5656,6 +5974,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
  "time 0.3.19",
+]
+
+[[package]]
+name = "yellowstone-grpc-client"
+version = "1.1.1+solana.1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf553cc928da8ff53b5fffcaa1fd2a11273989c9f8a9031121bf6006b33ac90b"
+dependencies = [
+ "bytes",
+ "futures 0.3.26",
+ "http",
+ "thiserror",
+ "tonic",
+ "yellowstone-grpc-proto",
+]
+
+[[package]]
+name = "yellowstone-grpc-proto"
+version = "1.1.0+solana.1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2688c6f1d930f21f580829f6f896d7d38f90d5b2272e53a8f69a82e72b656f"
+dependencies = [
+ "anyhow",
+ "prost",
+ "protobuf-src",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.52"
 solana-sdk = "1.10.32"
 borsh = "0.9.3"
 rand = "0.7.3"
-ellipsis-client = "0.1.14"
+ellipsis-client = "0.2.0"
 phoenix-v1 = { version = "0.2.2", features = [ "no-entrypoint" ]} 
 tokio = { version = "1.23.0", features = ["full"] }
 solana-client = "1.10.32"

--- a/rust/examples/src/bin/grpc.rs
+++ b/rust/examples/src/bin/grpc.rs
@@ -1,0 +1,79 @@
+use clap::Parser;
+use ellipsis_client::grpc_client::transaction_subscribe;
+use phoenix_sdk::sdk_client::SDKClient;
+use solana_sdk::{pubkey::Pubkey, signature::Keypair};
+use tokio::{sync::mpsc::channel, try_join};
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about)]
+struct Args {
+    #[clap(short, long)]
+    /// Service endpoint
+    url: String,
+
+    #[clap(long)]
+    x_token: Option<String>,
+
+    /// Filter included account in transactions
+    #[clap(long, value_delimiter = ' ')]
+    accounts_to_include: Vec<Pubkey>,
+
+    /// Filter excluded account in transactions
+    #[clap(long, value_delimiter = ' ')]
+    accounts_to_exclude: Vec<Pubkey>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let url = args.url.trim_end_matches("/").to_string();
+    let sdk_url = url.clone();
+
+    let (sender, mut receiver) = channel(10000);
+
+    let x_token = match args.x_token {
+        Some(t) => t,
+        None => {
+            // Split url by forward slash
+            let mut url_split: Vec<&str> = url.split("/").collect();
+            let token = url_split.pop().unwrap();
+            token.to_string()
+        }
+    };
+
+    let payer = Keypair::new();
+    let phoenix_sdk = SDKClient::new(&payer, &sdk_url).await?;
+
+    let market_data_sender = tokio::spawn(async move {
+        transaction_subscribe(
+            url.clone(),
+            Some(x_token),
+            sender,
+            args.accounts_to_include,
+            args.accounts_to_exclude,
+        )
+        .await
+    });
+
+    let handler = tokio::spawn(async move {
+        while let Some(transaction) = receiver.recv().await {
+            let events = phoenix_sdk.core.parse_events_from_transaction(&transaction);
+            if let Some(events) = events {
+                if let Some(parsed_events) = phoenix_sdk.parse_raw_phoenix_events(events).await {
+                    for event in parsed_events {
+                        println!("{:#?}", event);
+                    }
+                }
+            }
+        }
+    });
+
+    match try_join!(market_data_sender, handler) {
+        Ok(_) => {}
+        Err(_) => {
+            println!("Error");
+        }
+    }
+
+    Ok(())
+}

--- a/rust/examples/src/bin/grpc.rs
+++ b/rust/examples/src/bin/grpc.rs
@@ -8,17 +8,17 @@ use tokio::{sync::mpsc::channel, try_join};
 #[clap(author, version, about)]
 struct Args {
     #[clap(short, long)]
-    /// Service endpoint
+    /// gRPC service endpoint
     url: String,
 
     #[clap(long)]
     x_token: Option<String>,
 
-    /// Filter included account in transactions
+    /// Filter included accounts in transactions
     #[clap(long, value_delimiter = ' ')]
     accounts_to_include: Vec<Pubkey>,
 
-    /// Filter excluded account in transactions
+    /// Filter excluded accounts in transactions
     #[clap(long, value_delimiter = ' ')]
     accounts_to_exclude: Vec<Pubkey>,
 }

--- a/rust/phoenix-sdk-core/Cargo.toml
+++ b/rust/phoenix-sdk-core/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "phoenix-sdk-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "Core SDK for interacting with the Phoenix program"
 edition = "2021"
 license = "MIT"

--- a/rust/phoenix-sdk-core/src/sdk_client_core.rs
+++ b/rust/phoenix-sdk-core/src/sdk_client_core.rs
@@ -25,6 +25,7 @@ use phoenix::{
 use rand::{rngs::StdRng, Rng};
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use solana_sdk::signature::Signature;
+use std::str::FromStr;
 use std::{
     collections::BTreeMap,
     fmt::Display,
@@ -523,9 +524,9 @@ impl SDKClientCore {
 
     pub fn parse_events_from_transaction(
         &self,
-        sig: &Signature,
         tx: &ParsedTransaction,
     ) -> Option<Vec<RawPhoenixEvent>> {
+        let sig = Signature::from_str(&tx.signature).ok()?;
         let mut event_list = vec![];
         for inner_ixs in tx.inner_instructions.iter() {
             for inner_ix in inner_ixs.iter() {
@@ -549,7 +550,7 @@ impl SDKClientCore {
                 }
             }
         }
-        self.parse_raw_phoenix_events(sig, event_list)
+        self.parse_raw_phoenix_events(&sig, event_list)
     }
 }
 

--- a/rust/phoenix-sdk/Cargo.toml
+++ b/rust/phoenix-sdk/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "phoenix-sdk"
-version = "0.4.0"
+version = "0.4.1"
 description = "SDK for interacting with the Phoenix program"
 edition = "2021"
 license = "MIT"
@@ -29,7 +29,7 @@ rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }
 bytemuck = { workspace = true }
 itertools = "0.10.5"
-phoenix-sdk-core = { version = "0.4.0", path = "../phoenix-sdk-core" }
+phoenix-sdk-core = { version = "0.4.1", path = "../phoenix-sdk-core" }
 serde = { workspace = true }
 spl-associated-token-account = { workspace = true }
 phoenix-seat-manager = { workspace = true }


### PR DESCRIPTION
Changes:
- Add example of how to use gRPC to subscribe to phoenix events
- Update internal interface to no longer rely on passing in a signature in addition to a ParsedTransacation