### PR TITLE
add tif fields to L3Order and L3UiOrder types

### DIFF
--- a/typescript/phoenix-sdk/package.json
+++ b/typescript/phoenix-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/phoenix-sdk",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "TypeScript SDK for Phoenix",
   "author": "Ellipsis Labs",
   "repository": "https://github.com/Ellipsis-Labs/phoenix-sdk",

--- a/typescript/phoenix-sdk/src/market.ts
+++ b/typescript/phoenix-sdk/src/market.ts
@@ -48,6 +48,8 @@ export type L3Order = {
   sizeInBaseLots: BN;
   makerPubkey: string;
   orderSequenceNumber: BN;
+  lastValidSlot: BN;
+  lastValidUnixTimestampInSeconds: BN;
 };
 
 export type L3UiOrder = {
@@ -56,6 +58,8 @@ export type L3UiOrder = {
   size: number;
   makerPubkey: string;
   orderSequenceNumber: string;
+  lastValidSlot: number;
+  lastValidUnixTimestampInSeconds: number;
 };
 
 export type L3Book = {

--- a/typescript/phoenix-sdk/src/utils/market.ts
+++ b/typescript/phoenix-sdk/src/utils/market.ts
@@ -547,6 +547,10 @@ export function getMarketL3Book(
           toNum(restingOrder.traderIndex)
         ),
         orderSequenceNumber: getUiOrderSequenceNumber(orderId),
+        lastValidSlot: toBN(restingOrder.lastValidSlot),
+        lastValidUnixTimestampInSeconds: toBN(
+          restingOrder.lastValidUnixTimestampInSeconds
+        ),
       };
       if (side === Side.Ask) {
         asks.push(order);
@@ -615,6 +619,10 @@ function getL3UiOrder(l3Order: L3Order, marketData: MarketData): L3UiOrder {
       marketData.baseLotsPerBaseUnit,
     makerPubkey: l3Order.makerPubkey,
     orderSequenceNumber: l3Order.orderSequenceNumber.toString(),
+    lastValidSlot: toNum(l3Order.lastValidSlot),
+    lastValidUnixTimestampInSeconds: toNum(
+      l3Order.lastValidUnixTimestampInSeconds
+    ),
   };
 }
 


### PR DESCRIPTION
Add TIF fields to `L3Order` and `L3UiOrder` so that the front-end can manipulate expired and non-expired orders. Related to filtering of TIF orders and cancelling expired orders on the UI