### PR TITLE
Introduces a SDK function for simulating comprehensive Market Buy and Sell operations

### DIFF
--- a/rust/phoenix-sdk/src/ladder_utils.rs
+++ b/rust/phoenix-sdk/src/ladder_utils.rs
@@ -1,0 +1,183 @@
+use phoenix::state::{Side, markets::Ladder};
+
+#[derive(Debug, Clone)]
+pub struct SimulationSummaryInLots {
+    pub base_lots_filled: u64,
+    pub quote_lots_filled: u64,
+}
+
+// Trait definition
+pub trait MarketSimulator {
+    fn sell_quote(&self, num_lots_quote: u64) -> SimulationSummaryInLots;
+    fn sell_base(&self, num_lots_base: u64) -> SimulationSummaryInLots;
+    fn simulate_market_sell(&self, side: Side, size_in_lots: u64) -> SimulationSummaryInLots;
+}
+
+// Implementing the trait for Ladder
+impl MarketSimulator for Ladder {
+    fn sell_quote(&self, num_lots_quote: u64) -> SimulationSummaryInLots {
+        let mut remaining_quote_lots = num_lots_quote;
+        let mut base_lots = 0;
+
+        for ask in self.asks.iter() {
+            if remaining_quote_lots == 0 {
+                break;
+            }
+
+            let max_base_lots_you_can_buy = remaining_quote_lots / ask.price_in_ticks;
+            let amount_lots_to_buy = max_base_lots_you_can_buy.min(ask.size_in_base_lots);
+            base_lots += amount_lots_to_buy;
+            remaining_quote_lots -= amount_lots_to_buy * ask.price_in_ticks;
+        }
+
+        let quote_lots_used = num_lots_quote - remaining_quote_lots;
+        SimulationSummaryInLots {
+            base_lots_filled: base_lots,
+            quote_lots_filled: quote_lots_used,
+        }
+    }
+
+    fn sell_base(&self, num_lots_base: u64) -> SimulationSummaryInLots {
+        // Check the bids, these are orders to BUY
+        let mut remaining_base_lots = num_lots_base;
+        let mut quote_lots = 0;
+
+        for bid in self.bids.iter() {
+            if remaining_base_lots == 0 {
+                break;
+            }
+
+            let lots_to_fill = remaining_base_lots.min(bid.size_in_base_lots);
+            quote_lots += lots_to_fill * bid.price_in_ticks;
+            remaining_base_lots -= lots_to_fill;
+        }
+
+        let base_lots_used = num_lots_base - remaining_base_lots;
+        SimulationSummaryInLots {
+            base_lots_filled: base_lots_used,
+            quote_lots_filled: quote_lots,
+        }
+    }
+
+    fn simulate_market_sell(&self, side: Side, size_in_lots: u64) -> SimulationSummaryInLots {
+        match side {
+            Side::Bid => self.sell_quote(size_in_lots),
+            Side::Ask => self.sell_base(size_in_lots),
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use phoenix::state::markets::LadderOrder;
+    use super::*;
+
+    struct Fixture {
+        pub ladder: Ladder,
+        pub atoms_in_base_lot: f64,
+        pub atoms_in_quote_lot: f64,
+        pub atoms_in_base_unit: f64,
+        pub atoms_in_quote_unit: f64,
+    }
+
+    // This is a very simplified ladder for SOL/USDC on Phoenix
+    fn get_sol_usdc_ladder() -> Fixture {
+        let ladder = Ladder {
+            bids: vec![
+                LadderOrder { price_in_ticks: 0x58bf, size_in_base_lots: 0x043f },
+                LadderOrder { price_in_ticks: 0x58b9, size_in_base_lots: 0x043f },
+                LadderOrder { price_in_ticks: 0x58a7, size_in_base_lots: 0x043f },
+            ],
+            asks: vec![
+                LadderOrder { price_in_ticks: 0x58c0, size_in_base_lots: 0x3036 },
+                LadderOrder { price_in_ticks: 0x58c0, size_in_base_lots: 0x01e1ff },
+                LadderOrder { price_in_ticks: 0x58c0, size_in_base_lots: 0x02a261 },
+            ],
+        };
+        let fixture = Fixture {
+            ladder,
+            atoms_in_base_lot: 1e6,
+            atoms_in_quote_lot: 1.,
+            atoms_in_base_unit: 1e9,
+            atoms_in_quote_unit: 1e6,
+        };
+        fixture
+    }
+    
+    fn lots_to_unit_amount(lots: u64, lots_to_atoms: f64, atoms_to_unit: f64) -> f64 {
+        let atoms = lots_to_atoms * lots as f64;
+        let unit = atoms / atoms_to_unit;
+        unit
+    }
+
+    #[test]
+    fn test_empty_ladder_sell() {
+        let ladder = Ladder {
+            bids: vec![],
+            asks: vec![],
+        };
+        let result = ladder.simulate_market_sell(Side::Ask, 1000);
+        assert_eq!(result.base_lots_filled, 0);
+        assert_eq!(result.quote_lots_filled, 0);
+    }
+    
+    #[test]
+    fn test_sell_more_than_available() {
+        let Fixture{ladder, ..} = get_sol_usdc_ladder();
+
+        // Compute the max lots you can sell
+        let max_lots_purchaseable: u64 = ladder.bids.iter().map(|bid| bid.size_in_base_lots).sum();
+        
+        // Sell twice as much, and assert that only the max is filled
+        let to_purchase = max_lots_purchaseable * 2;
+        let result = ladder.simulate_market_sell(Side::Ask, to_purchase);
+        assert_eq!(result.base_lots_filled, max_lots_purchaseable);
+        assert!(result.quote_lots_filled > 0);
+    }
+
+    #[test]
+    fn test_buy_more_than_available() {
+        let Fixture{ladder, ..} = get_sol_usdc_ladder();
+    
+        // Compute the max lots you can buy (from available asks)
+        let max_lots_sellable: u64 = ladder.asks.iter().map(|ask| ask.size_in_base_lots * ask.price_in_ticks).sum();
+        
+        // Try to buy twice as much, which means you are selling twice as much base
+        let to_sell = max_lots_sellable * 2;
+        let result = ladder.simulate_market_sell(Side::Bid, to_sell);
+        
+        assert_eq!(result.quote_lots_filled, max_lots_sellable);
+        assert!(result.quote_lots_filled > 0);
+    }
+
+
+    #[test]
+    fn test_simulate_market() {
+        let test_cases = vec![
+            (Side::Ask, 3000, 3000, 68130654, "22.710"),
+            (Side::Ask, 6000, 3261, 74054049, "22.709"),
+            (Side::Bid, 68000000, 2992, 67978240, "22.720"),
+            (Side::Ask, 0, 0, 0, "0.000"),
+            (Side::Bid, 0, 0, 0, "0.000"),
+        ];
+    
+        for (side, input, expected_base, expected_quote, expected_price) in test_cases.into_iter() {
+            let fixture = get_sol_usdc_ladder();
+            let ladder = fixture.ladder;
+            let result = ladder.simulate_market_sell(side, input);
+            assert_eq!(result.base_lots_filled, expected_base, "Failed for side {:?} with input {}", side, input);
+            assert_eq!(result.quote_lots_filled, expected_quote, "Failed for side {:?} with input {}", side, input);
+            let price = match result.base_lots_filled {
+                0 => 0.0,
+                _ => {
+                    let base_units = lots_to_unit_amount(result.base_lots_filled, fixture.atoms_in_base_lot, fixture.atoms_in_base_unit);
+                    let quote_units = lots_to_unit_amount(result.quote_lots_filled, fixture.atoms_in_quote_lot, fixture.atoms_in_quote_unit);
+                    quote_units / base_units
+                }
+            };
+            let price_formatted = format!("{:.3}", price);
+            assert_eq!(price_formatted, expected_price, "Price mismatch for side {:?} with input {}", side, input);
+        }
+    }
+}

--- a/rust/phoenix-sdk/src/ladder_utils.rs
+++ b/rust/phoenix-sdk/src/ladder_utils.rs
@@ -6,14 +6,12 @@ pub struct SimulationSummaryInLots {
     pub quote_lots_filled: u64,
 }
 
-// Trait definition
 pub trait MarketSimulator {
     fn sell_quote(&self, num_lots_quote: u64) -> SimulationSummaryInLots;
     fn sell_base(&self, num_lots_base: u64) -> SimulationSummaryInLots;
     fn simulate_market_sell(&self, side: Side, size_in_lots: u64) -> SimulationSummaryInLots;
 }
 
-// Implementing the trait for Ladder
 impl MarketSimulator for Ladder {
     fn sell_quote(&self, num_lots_quote: u64) -> SimulationSummaryInLots {
         let mut remaining_quote_lots = num_lots_quote;
@@ -38,7 +36,6 @@ impl MarketSimulator for Ladder {
     }
 
     fn sell_base(&self, num_lots_base: u64) -> SimulationSummaryInLots {
-        // Check the bids, these are orders to BUY
         let mut remaining_base_lots = num_lots_base;
         let mut quote_lots = 0;
 

--- a/rust/phoenix-sdk/src/lib.rs
+++ b/rust/phoenix-sdk/src/lib.rs
@@ -2,3 +2,4 @@ pub use phoenix_sdk_core::orderbook;
 pub mod order_packet_template;
 pub mod sdk_client;
 pub mod utils;
+pub mod ladder_utils;

--- a/rust/phoenix-sdk/src/lib.rs
+++ b/rust/phoenix-sdk/src/lib.rs
@@ -1,5 +1,5 @@
 pub use phoenix_sdk_core::orderbook;
+pub mod ladder_utils;
 pub mod order_packet_template;
 pub mod sdk_client;
 pub mod utils;
-pub mod ladder_utils;

--- a/rust/phoenix-sdk/src/sdk_client.rs
+++ b/rust/phoenix-sdk/src/sdk_client.rs
@@ -5,8 +5,10 @@ use crate::utils::create_ata_ix_if_needed;
 use crate::utils::create_claim_seat_ix_if_needed;
 use anyhow::anyhow;
 use anyhow::Result;
+use anyhow::bail;
 use ellipsis_client::EllipsisClient;
 use phoenix::program::create_new_order_instruction;
+use phoenix::program::dispatch_market;
 use phoenix::program::dispatch_market::*;
 use phoenix::program::EvictEvent;
 use phoenix::program::ExpiredOrderEvent;
@@ -59,6 +61,55 @@ pub struct MarketInfoConfig {
     pub market: String,
     pub baseMint: String,
     pub quoteMint: String,
+}
+
+const FEE_DIVISOR: u64 = 10000;
+
+#[derive(Debug, Clone)]
+pub struct MarketSimulationResultInAtoms {
+    pub base_atoms_filled: u64,
+    pub quote_atoms_filled: u64,
+}
+
+impl MarketSimulationResultInAtoms {
+    pub fn get_price_in_ticks(&self) -> f64 {
+        self.quote_atoms_filled as f64 / self.base_atoms_filled as f64
+    }
+}
+
+pub struct MarketWrapper2 {
+    meta: MarketMetadata,
+    bytes: Vec<u8>,
+}
+
+impl<'a> MarketWrapper2 {
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    pub fn new(account_data: Vec<u8>) -> Result<Self> {
+        let (header_bytes, bytes) = account_data.split_at(size_of::<MarketHeader>());
+        let meta = bytemuck::try_from_bytes(header_bytes)
+            .map_err(|_| anyhow!("Failed to deserialize market header"))
+            .and_then(MarketMetadata::from_header)?;
+        Ok(Self {
+            meta,
+            bytes: bytes.to_vec(),
+        })
+    }
+
+    pub fn get_market_wrapper(&self) -> Result<MarketWrapper<Pubkey, FIFOOrderId, FIFORestingOrder, OrderPacket>> {
+        let market = load_with_dispatch(&self.meta.market_size_params, &self.bytes)
+            .map_err(|_| anyhow!("Market configuration not found"))?;
+        Ok(market)
+    }
+
+}
+
+#[derive(Debug, Default)]
+pub struct LadderExpiration {
+    pub last_valid_slot: Option<u64>,
+    pub last_valid_unix_timestamp_in_seconds: Option<u64>,
 }
 
 pub struct SDKClient {
@@ -286,21 +337,12 @@ impl SDKClient {
         match self.markets.get(market_key) {
             Some(metadata) => Ok(*metadata),
             None => {
-                let market_account_data = (self.client.get_account_data(market_key))
-                    .await
-                    .map_err(|_| anyhow!("Failed to find market account"))?;
-                self.get_market_metadata_from_header_bytes(
-                    &market_account_data[..size_of::<MarketHeader>()],
-                )
+                let wrapper = self.get_market_wrapper(market_key).await?;
+                Ok(wrapper.meta)
             }
         }
     }
 
-    fn get_market_metadata_from_header_bytes(&self, header_bytes: &[u8]) -> Result<MarketMetadata> {
-        bytemuck::try_from_bytes(header_bytes)
-            .map_err(|_| anyhow!("Failed to deserialize market header"))
-            .and_then(MarketMetadata::from_header)
-    }
 
     /// Fetches a market's metadata from the SDKClient's market cache. This cache must be
     /// explicitly populated by calling `add_market` or `add_all_markets`.
@@ -320,17 +362,17 @@ impl SDKClient {
         }
     }
 
-    pub async fn get_market_ladder(&self, market_key: &Pubkey, levels: u64) -> Result<Ladder> {
+    async fn get_market_wrapper(&self, market_key: &Pubkey) -> Result<MarketWrapper2> {
         let market_account_data = (self.client.get_account_data(market_key))
             .await
             .map_err(|_| anyhow!("Failed to get market account data"))?;
-        let (header_bytes, bytes) = market_account_data.split_at(size_of::<MarketHeader>());
-        let meta = self.get_market_metadata_from_header_bytes(header_bytes)?;
-        let market = load_with_dispatch(&meta.market_size_params, bytes)
-            .map_err(|_| anyhow!("Market configuration not found"))?
-            .inner;
+        MarketWrapper2::new(market_account_data)
+    }
 
-        Ok(market.get_ladder(levels))
+    pub async fn get_market_ladder(&self, market_key: &Pubkey, levels: u64) -> Result<Ladder> {
+        let market = self.get_market_wrapper(market_key).await?;
+        let wrapper = market.get_market_wrapper()?;
+        Ok(wrapper.inner.get_ladder(levels))
     }
 
     pub fn get_market_ladder_sync(&self, market_key: &Pubkey, levels: u64) -> Result<Ladder> {
@@ -338,35 +380,84 @@ impl SDKClient {
         rt.block_on(self.get_market_ladder(market_key, levels))
     }
 
+    pub async fn simulate_market_transaction(
+        &self,
+        market_key: &Pubkey,
+        input_mint_key: &Pubkey,
+        atoms: u64,
+        expiration: Option<LadderExpiration>,
+    ) -> Result<MarketSimulationResultInAtoms> {
+        let LadderExpiration{last_valid_slot, last_valid_unix_timestamp_in_seconds} = expiration.unwrap_or_default();
+        let wrapper = self.get_market_wrapper(market_key).await?;
+        let market = wrapper.get_market_wrapper()?;
+        let ladder = market.inner.get_ladder_with_expiration(u64::MAX, last_valid_slot, last_valid_unix_timestamp_in_seconds);
+        let metadata = self.get_market_metadata_from_cache(market_key)?;
+        let side = match input_mint_key {
+            _ if input_mint_key == &metadata.base_mint => Side::Ask,
+            _ if input_mint_key == &metadata.quote_mint => Side::Bid,
+            _ => bail!("Input mint key does not match market base or quote mint")
+        };
+        println!("side: {:?}", side);
+
+        // convert atoms to lots
+        let mut lots_to_sell = match side {
+            Side::Bid => metadata.quote_atoms_to_quote_lots_rounded_down(atoms),
+            Side::Ask => metadata.base_atoms_to_base_lots_rounded_down(atoms)
+        };
+
+        // If the input is quote, apply the fee before the swap
+        if side == Side::Bid {
+            let fee = market.inner.get_taker_fee_bps();
+            lots_to_sell = lots_to_sell * (FEE_DIVISOR - fee) / FEE_DIVISOR;
+        }
+
+        let simulation_result = ladder.simulate_market_sell(side, lots_to_sell);
+
+        // If the output is quote, apply the fee after the swap
+        let simulation_result = match side {
+            Side::Bid => simulation_result,
+            Side::Ask => {
+                let fee = market.inner.get_taker_fee_bps();
+                let quote_lots_filled = simulation_result.quote_lots_filled * (FEE_DIVISOR - fee) / FEE_DIVISOR;
+                MarketSimulationResult{
+                    base_lots_filled: simulation_result.base_lots_filled,
+                    quote_lots_filled
+                }
+            }
+        };
+        println!("simulation_result: {:?}", simulation_result);
+
+        // Convert lots to atoms
+        let base_atoms_filled = metadata.base_lots_to_base_atoms(simulation_result.base_lots_filled);
+        let quote_atoms_filled = metadata.quote_lots_to_quote_atoms(simulation_result.quote_lots_filled);
+        Ok(MarketSimulationResultInAtoms{base_atoms_filled, quote_atoms_filled})
+    }
+
     pub async fn get_market_orderbook(
         &self,
         market_key: &Pubkey,
     ) -> Result<Orderbook<FIFOOrderId, PhoenixOrder>> {
-        let market_account_data = (self.client.get_account_data(market_key))
-            .await
-            .unwrap_or_default();
+        let wrapper = self.get_market_wrapper(market_key).await?;
         let default_orderbook = Orderbook::<FIFOOrderId, PhoenixOrder> {
+            taker_fee_bps: 0,
             raw_base_units_per_base_lot: 0.0,
             quote_units_per_raw_base_unit_per_tick: 0.0,
             bids: BTreeMap::new(),
             asks: BTreeMap::new(),
         };
-        if market_account_data.is_empty() {
+        if wrapper.is_empty() {
             return Ok(default_orderbook);
         }
-        let (header_bytes, bytes) = market_account_data.split_at(size_of::<MarketHeader>());
-        let meta = self.get_market_metadata_from_header_bytes(header_bytes)?;
+        let meta = &wrapper.meta;
         let raw_base_units_per_base_lot = meta.raw_base_units_per_base_lot();
         let quote_units_per_raw_base_unit_per_tick = meta.quote_units_per_raw_base_unit_per_tick();
-        Ok(load_with_dispatch(&meta.market_size_params, bytes)
-            .map(|market| {
-                Orderbook::from_market(
-                    market.inner,
-                    raw_base_units_per_base_lot,
-                    quote_units_per_raw_base_unit_per_tick,
-                )
-            })
-            .unwrap_or_else(|_| default_orderbook.clone()))
+        let market = wrapper.get_market_wrapper()?;
+        let orderbook = Orderbook::from_market(
+            market.inner,
+            raw_base_units_per_base_lot,
+            quote_units_per_raw_base_unit_per_tick,
+        );
+        Ok(orderbook)
     }
 
     pub async fn get_market_orderbook_sync(
@@ -381,17 +472,10 @@ impl SDKClient {
         &self,
         market_key: &Pubkey,
     ) -> Result<BTreeMap<Pubkey, TraderState>> {
-        let market_account_data = match (self.client.get_account_data(market_key)).await {
-            Ok(data) => data,
-            Err(_) => return Ok(BTreeMap::new()),
-        };
-        let (header_bytes, bytes) = market_account_data.split_at(size_of::<MarketHeader>());
-        let meta = self.get_market_metadata_from_header_bytes(header_bytes)?;
-        let market = load_with_dispatch(&meta.market_size_params, bytes)
-            .map_err(|_| anyhow!("Market configuration not found"))?
-            .inner;
-
+        let wrapper = self.get_market_wrapper(market_key).await?;
+        let market = wrapper.get_market_wrapper()?;
         Ok(market
+            .inner
             .get_registered_traders()
             .iter()
             .map(|(k, v)| (*k, *v))
@@ -407,11 +491,12 @@ impl SDKClient {
     }
 
     pub async fn get_market_state(&self, market_key: &Pubkey) -> Result<MarketState> {
-        let market_account_data = match (self.client.get_account_data(market_key)).await {
+        let wrapper = match self.get_market_wrapper(market_key).await {
             Ok(data) => data,
             Err(_) => {
                 return Ok(MarketState {
                     orderbook: Orderbook {
+                        taker_fee_bps: 0,
                         raw_base_units_per_base_lot: 0.0,
                         quote_units_per_raw_base_unit_per_tick: 0.0,
                         bids: BTreeMap::new(),
@@ -421,11 +506,8 @@ impl SDKClient {
                 })
             }
         };
-        let (header_bytes, bytes) = market_account_data.split_at(size_of::<MarketHeader>());
-        let meta = self.get_market_metadata_from_header_bytes(header_bytes)?;
-        let market = load_with_dispatch(&meta.market_size_params, bytes)
-            .map_err(|_| anyhow!("Market configuration not found"))?
-            .inner;
+        let meta = &wrapper.meta;
+        let market = wrapper.get_market_wrapper()?.inner;
         let orderbook = Orderbook::from_market(
             market,
             meta.raw_base_units_per_base_lot(),

--- a/rust/phoenix-sdk/src/sdk_client.rs
+++ b/rust/phoenix-sdk/src/sdk_client.rs
@@ -467,14 +467,14 @@ impl SDKClient {
     ///
     /// * `market_key` - The public key of the Phoenix market.
     /// * `input_mint_key` - The public key of the input Mint.
-    /// * `atoms` - The amount in atoms to sell.
+    /// * `atoms_to_sell` - The amount in atoms to sell.
     /// * `expiration` - Expiration details for the simulation (optional but recommended for real-time simulations).
     ///
     pub async fn simulate_market_transaction(
         &self,
         market_key: &Pubkey,
         input_mint_key: &Pubkey,
-        atoms: u64,
+        atoms_to_sell: u64,
         expiration: Option<LadderExpiration>,
     ) -> Result<SimulationSummaryInAtoms> {
         let LadderExpiration{last_valid_slot, last_valid_unix_timestamp_in_seconds} = expiration.unwrap_or_default();
@@ -496,8 +496,8 @@ impl SDKClient {
 
         // convert atoms to lots
         let mut lots_to_sell = match side {
-            Side::Bid => metadata.quote_atoms_to_quote_lots_rounded_down(atoms),
-            Side::Ask => metadata.base_atoms_to_base_lots_rounded_down(atoms)
+            Side::Bid => metadata.quote_atoms_to_quote_lots_rounded_down(atoms_to_sell),
+            Side::Ask => metadata.base_atoms_to_base_lots_rounded_down(atoms_to_sell)
         };
 
         // If the input is quote, apply the fee before the swap

--- a/rust/phoenix-sdk/src/sdk_client.rs
+++ b/rust/phoenix-sdk/src/sdk_client.rs
@@ -66,15 +66,9 @@ pub struct MarketInfoConfig {
 const FEE_DIVISOR: u64 = 10000;
 
 #[derive(Debug, Clone)]
-pub struct MarketSimulationResultInAtoms {
+pub struct SimulationSummaryInAtoms {
     pub base_atoms_filled: u64,
     pub quote_atoms_filled: u64,
-}
-
-impl MarketSimulationResultInAtoms {
-    pub fn get_price_in_ticks(&self) -> f64 {
-        self.quote_atoms_filled as f64 / self.base_atoms_filled as f64
-    }
 }
 
 pub struct MarketWrapper2 {
@@ -386,7 +380,7 @@ impl SDKClient {
         input_mint_key: &Pubkey,
         atoms: u64,
         expiration: Option<LadderExpiration>,
-    ) -> Result<MarketSimulationResultInAtoms> {
+    ) -> Result<SimulationSummaryInAtoms> {
         let LadderExpiration{last_valid_slot, last_valid_unix_timestamp_in_seconds} = expiration.unwrap_or_default();
         let wrapper = self.get_market_wrapper(market_key).await?;
         let market = wrapper.get_market_wrapper()?;
@@ -430,7 +424,7 @@ impl SDKClient {
         // Convert lots to atoms
         let base_atoms_filled = metadata.base_lots_to_base_atoms(simulation_result.base_lots_filled);
         let quote_atoms_filled = metadata.quote_lots_to_quote_atoms(simulation_result.quote_lots_filled);
-        Ok(MarketSimulationResultInAtoms{base_atoms_filled, quote_atoms_filled})
+        Ok(SimulationSummaryInAtoms{base_atoms_filled, quote_atoms_filled})
     }
 
     pub async fn get_market_orderbook(


### PR DESCRIPTION
In this pull request, I've added a `simulate_market_transaction` function that allows for simulating market buys/sells off-chain (without using [simulateTransaction](https://www.quicknode.com/docs/solana/simulateTransaction))

### Key Changes:
- Added based orderbook tallying for `Ladder` - this was done in a trait `MarketSimulator` that was attached to the `Ladder` struct (without having to change `phoenix-v1`)
- Added `simulate_market_transaction` on the SDK which is the main entrypoint and wrapper around the new `MarketSimulator` code. This function accounts for lots/atoms conversion and adds fees appropriately.
- Added unit tests for Ladder

🔐 Security-wise: all functions are non `&mut`, and there are no code deletions - only additions.

### Testing Considerations:
- The `simulate_market_transaction` function in SDK currently lacks tests since it's tightly coupled with networking. We can solve this in a follow up PR by allowing the function to process raw data without network dependencies. Once we do this, we'll be in a position to implement dedicated tests for it.

### How to review

Suggested way to review
- Start from Ladder code changes
- Ensure unit tests are correct
- Review the SDK changes
- Specifically, make sure the fees are adjusted for appropriately 

### E2E tests using Phoenix CLI:

I did some E2E tests by creating a dummy function on `phoenix-cli` which calls `simulate_market_transaction` on an assortment of prices and directions. `IN` specifies what we are selling and `OUT` is the outcome of the swap

```
SOL/USD book
--------------------------------------------


[IN] Token: So11111111111111111111111111111111111111112
[IN] Amount size: 200 SOL
[IN] Amount atoms: 200000000000
[OUT] Base 200 (200000000000 atoms)
[OUT] Quote 4000.840321 (4000840321 atoms)
[OUT] Price: 20.004201605000002
--------------------------------------------
[IN] Token: So11111111111111111111111111111111111111112
[IN] Amount size: 500  SOL
[IN] Amount atoms: 500000000000
[OUT] Base 500 (500000000000 atoms)
[OUT] Quote 10001.170765 (10001170765 atoms)
[OUT] Price: 20.002341530000002
--------------------------------------------
[IN] Token: So11111111111111111111111111111111111111112
[IN] Amount size: 10000  SOL
[IN] Amount atoms: 10000000000000
[OUT] Base 6342.761 (6342761000000 atoms)  👈 Book exhausted
[OUT] Quote 68833.945844 (68833945844 atoms)
[OUT] Price: 10.852363165504737


--------------------------------------------
[IN] Token: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
[IN] Amount size: 200 USDC
[IN] Amount atoms: 200000000
[OUT] Base 9.988 (9988000000 atoms)
[OUT] Quote 199.95976 (199959760 atoms)
[OUT] Price: 20.02
--------------------------------------------
[IN] Token: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
[IN] Amount size: 500 USDC
[IN] Amount atoms: 500000000
[OUT] Base 24.967 (24967000000 atoms)
[OUT] Quote 499.880829 (499880829 atoms)
[OUT] Price: 20.02166175351464
--------------------------------------------
[IN] Token: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
[IN] Amount size: 10000 USDC
[IN] Amount atoms: 10000000000
[OUT] Base 499.258 (499258000000 atoms)
[OUT] Quote 9997.999507 (9997999507 atoms)
[OUT] Price: 20.025717178292588
```
Appreciate your feedback! and let me know what you think
