### PR TITLE
Jarry/fix ts sdk bug

### DIFF
--- a/typescript/phoenix-sdk/package.json
+++ b/typescript/phoenix-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/phoenix-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "TypeScript SDK for Phoenix",
   "author": "Ellipsis Labs",
   "repository": "https://github.com/Ellipsis-Labs/phoenix-sdk",

--- a/typescript/phoenix-sdk/src/client.ts
+++ b/typescript/phoenix-sdk/src/client.ts
@@ -145,11 +145,8 @@ export class Client {
     accountList.push(SYSVAR_CLOCK_PUBKEY);
 
     const accounts = useZstd
-      ? await getConfirmedMarketsAndClockAccountsZstd(
-          connection,
-          marketAddresses
-        )
-      : await getConfirmedMarketsAndClockAccounts(connection, marketAddresses);
+      ? await getConfirmedMarketsAndClockAccountsZstd(connection, accountList)
+      : await getConfirmedMarketsAndClockAccounts(connection, accountList);
 
     const clockBuffer = accounts.pop();
     if (clockBuffer === undefined) {


### PR DESCRIPTION
The ts client fetches 1MB+ worth of data for no reason. The skipInitialFetch flag does not actually work