### PR TITLE
fix confirmOrCreateClaimSeatIxs for evicted users

### DIFF
--- a/typescript/phoenix-sdk/package.json
+++ b/typescript/phoenix-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/phoenix-sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "TypeScript SDK for Phoenix",
   "author": "Ellipsis Labs",
   "repository": "https://github.com/Ellipsis-Labs/phoenix-sdk",

--- a/typescript/phoenix-sdk/src/utils/seatManager.ts
+++ b/typescript/phoenix-sdk/src/utils/seatManager.ts
@@ -195,7 +195,7 @@ export async function confirmOrCreateClaimSeatIxs(
     instructions.push(getClaimSeatIx(marketState.address, trader));
   } else {
     const seatAccount = seatBeet.deserialize(seatAccountInfo.data);
-    if (seatAccount[0].approvalStatus !== SeatApprovalStatus.Approved) {
+    if (Number(seatAccount[0].approvalStatus) !== SeatApprovalStatus.Approved) {
       instructions.push(getClaimSeatIx(marketState.address, trader));
     }
   }

--- a/typescript/phoenix-sdk/src/utils/seatManager.ts
+++ b/typescript/phoenix-sdk/src/utils/seatManager.ts
@@ -5,7 +5,7 @@ import {
 import { Connection, PublicKey, TransactionInstruction } from "@solana/web3.js";
 import * as beet from "@metaplex-foundation/beet";
 import * as beetSolana from "@metaplex-foundation/beet-solana";
-import { getLogAuthority, getSeatAddress, MarketState, PROGRAM_ID } from "..";
+import { getLogAuthority, getSeatAddress, MarketState, PROGRAM_ID, SeatApprovalStatus, seatBeet } from "..";
 
 import {
   createEvictSeatInstruction,
@@ -165,7 +165,7 @@ export function getEvictSeatIx(
 }
 
 /**
- * Checks if the given trader has a seat on the given market
+ * Checks if the given trader has an approved seat on the given market
  * If not, return claim seat instructions
  * @param connection An instance of the Connection class
  * @param marketState The market object
@@ -193,6 +193,11 @@ export async function confirmOrCreateClaimSeatIxs(
       instructions.push(getEvictSeatIx(marketState, traderToEvict, trader));
     }
     instructions.push(getClaimSeatIx(marketState.address, trader));
+  } else {
+    const seatAccount = seatBeet.deserialize(seatAccountInfo.data);
+    if (seatAccount[0].approvalStatus !== SeatApprovalStatus.Approved) {
+      instructions.push(getClaimSeatIx(marketState.address, trader));
+    }
   }
 
   return instructions;


### PR DESCRIPTION
Currently `confirmOrCreateClaimSeatIxs` only returns setup instructions for a brand new trader (no Seat account), a trader may also have an existing Seat account without an `Approved` status. This PR will return a `claim_seat` instruction for users with an existing unapproved Seat account.