### PR TITLE
fix: 404 link in `ata_utils.rs`

### DIFF
--- a/rust/crates/phoenix-sdk-core/src/ata_utils.rs
+++ b/rust/crates/phoenix-sdk-core/src/ata_utils.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-// Copy-pasted from https://github.com/solana-labs/solana-program-library/blob/master/associated-token-account/program/src/lib.rs
+// Copy-pasted from https://github.com/solana-program/associated-token-account/blob/main/program/src/lib.rs
 // Solana dependency graph is too complicated. I don't want to talk about it
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},


### PR DESCRIPTION
Hi! Caught a 404 error in our code comments - the link to Solana's Associated Token Account program was pointing to an old location (`solana-program-library/master/...`). Team moved this to a dedicated repo, so I've updated it to:  
https://github.com/solana-program/associated-token-account/blob/main/program/src/lib.rs

---

[solana-labs/spl@87c340d](https://github.com/solana-labs/solana-program-library/commit/87c340da6726e63dc324c23c633f4eb642497527) - shows the migration of associated-token-account to its new home.  
