### PR TITLE
fix: Prevent potential panic when extracting `x_token` from URL

### DIFF
--- a/rust/examples/src/bin/grpc.rs
+++ b/rust/examples/src/bin/grpc.rs
@@ -34,10 +34,11 @@ async fn main() -> anyhow::Result<()> {
     let x_token = match args.x_token {
         Some(t) => t,
         None => {
-            // Split url by forward slash
-            let mut url_split: Vec<&str> = url.split('/').collect();
-            let token = url_split.pop().unwrap();
-            token.to_string()
+            let mut url_split: Vec<&str> = url.rsplitn(2, '/').collect();
+            if url_split.len() < 2 {
+                return Err(anyhow::anyhow!("Invalid URL format, cannot extract x_token"));
+            }
+            url_split[0].to_string()
         }
     };
 


### PR DESCRIPTION
Noticed a potential issue in the `x_token` extraction logic. If the provided URL doesn’t contain a `/`, the `.pop().unwrap()` call could cause a panic.  

To prevent this, I replaced `url.split('/')` with `url.rsplitn(2, '/')` and added a check to ensure we have enough parts before attempting to extract `x_token`.

Now, if the URL format is invalid, the code returns an error instead of panicking.  
