### PR TITLE
Rename Phoenix references to Phoenix Legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Phoenix SDK
+# Phoenix Legacy SDK
 
-An SDK for interacting with the Phoenix program.
+An SDK for interacting with the Phoenix Legacy program.
 
 We currently support Rust, Typescript, and [Python](https://github.com/Ellipsis-Labs/phoenixpy).
 
@@ -31,7 +31,7 @@ async function simpleSwap() {
     )
   );
 
-  // Create a Phoenix client and select a market
+  // Create a Phoenix Legacy client and select a market
   const phoenix = await Phoenix.Client.create(connection);
   const marketConfig = phoenix.marketConfigs.find((market) => market.name === "SOL/USDC");
   if (!marketConfig) {

--- a/rust/crates/phoenix-sdk-core/Cargo.toml
+++ b/rust/crates/phoenix-sdk-core/Cargo.toml
@@ -3,7 +3,7 @@ cargo-features = ["workspace-inheritance"]
 [package]
 name = "phoenix-sdk-core"
 version = "0.8.0"
-description = "Core SDK for interacting with the Phoenix program"
+description = "Core SDK for interacting with the Phoenix Legacy program"
 edition = "2021"
 license = "MIT"
 
@@ -21,4 +21,3 @@ anyhow = { workspace = true }
 ellipsis-transaction-utils = { workspace = true }
 bytemuck = { workspace = true }
 spl-token = { workspace = true }
-

--- a/rust/crates/phoenix-sdk-core/src/sdk_client_core.rs
+++ b/rust/crates/phoenix-sdk-core/src/sdk_client_core.rs
@@ -103,7 +103,7 @@ pub struct MarketMetadata {
     pub base_atoms_per_base_lot: u64,
     pub tick_size_in_quote_atoms_per_base_unit: u64,
     pub num_base_lots_per_base_unit: u64,
-    /// The adjustment factor to convert from the raw base unit (i.e. 1 BONK token) to the Phoenix BaseUnit (which may be a multiple of whole tokens).
+    /// The adjustment factor to convert from the raw base unit (i.e. 1 BONK token) to the Phoenix Legacy BaseUnit (which may be a multiple of whole tokens).
     /// The adjustment factor is almost always 1, unless one base token is worth less than one quote atom (i.e. 1e-6 USDC)
     pub raw_base_units_per_base_unit: u32,
     pub market_size_params: MarketSizeParams,

--- a/rust/crates/phoenix-sdk/Cargo.toml
+++ b/rust/crates/phoenix-sdk/Cargo.toml
@@ -3,7 +3,7 @@ cargo-features = ["workspace-inheritance"]
 [package]
 name = "phoenix-sdk"
 version = "0.8.0"
-description = "SDK for interacting with the Phoenix program"
+description = "SDK for interacting with the Phoenix Legacy program"
 edition = "2021"
 license = "MIT"
 
@@ -31,4 +31,3 @@ bytemuck = { workspace = true }
 itertools = "0.10.5"
 phoenix-sdk-core = { version = "0.8.0", path = "../phoenix-sdk-core" }
 serde = { workspace = true }
-

--- a/rust/crates/phoenix-sdk/src/sdk_client.rs
+++ b/rust/crates/phoenix-sdk/src/sdk_client.rs
@@ -465,7 +465,7 @@ impl SDKClient {
     ///
     /// # Arguments
     ///
-    /// * `market_key` - The public key of the Phoenix market.
+    /// * `market_key` - The public key of the Phoenix Legacy market.
     /// * `input_mint_key` - The public key of the input Mint.
     /// * `atoms_to_sell` - The amount in atoms to sell.
     /// * `expiration` - Expiration details for the simulation (optional but recommended for real-time simulations).
@@ -846,7 +846,7 @@ impl SDKClient {
     }
 }
 
-/// Functions for sending transactions that interact with the Phoenix program
+/// Functions for sending transactions that interact with the Phoenix Legacy program
 impl SDKClient {
     pub async fn send_ioc(
         &self,

--- a/rust/examples/src/bin/simple_market_maker.rs
+++ b/rust/examples/src/bin/simple_market_maker.rs
@@ -69,7 +69,7 @@ pub fn get_network(network_str: &str) -> &str {
 // `cargo run --bin simple_market_maker -- -m CS2H8nbAVVEUHWPF5extCSymqheQdkd4d7thik6eet9N -u $YOUR_DEVNET_RPC_ENDPOINT`
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Connect to the solana network and create a Phoenix Client with your trader keypair and the market pubkey.
+    // Connect to the solana network and create a Phoenix Legacy Client with your trader keypair and the market pubkey.
     let args = Args::parse();
     let config = match CONFIG_FILE.as_ref() {
         Some(config_file) => Config::load(config_file).unwrap_or_else(|_| {
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
         setup_tx
     );
 
-    // To place limit orders on Phoenix, you need to ensure that you have associated token accounts for the base and quote tokens, and that you have a seat on the market.
+    // To place limit orders on Phoenix Legacy, you need to ensure that you have associated token accounts for the base and quote tokens, and that you have a seat on the market.
     // This method checks these requirements and returns instructions to create the necessary accounts, if needed:
     // - Creation of associated token accounts for base and quote tokens, if needed.
     // - Claiming of the market's seat, if needed.
@@ -224,7 +224,7 @@ async fn cancel_and_place_quotes(
     println!("Placing ask for size {}, price {}", ask_size, ask_price);
 
     let market_metadata = sdk.get_market_metadata(market).await?;
-    // Use an SDK-provided helper function to convert the limit order template into a limit order instruction, which contains Phoenix-specific units that the orderbook uses.
+    // Use an SDK-provided helper function to convert the limit order template into a limit order instruction, which contains Phoenix Legacy-specific units that the orderbook uses.
     let bid_ix =
         sdk.get_limit_order_ix_from_template(market, &market_metadata, &bid_limit_order_template)?;
 

--- a/typescript/phoenix-sdk/examples/decodeMainnetPhoenixTransaction.ts
+++ b/typescript/phoenix-sdk/examples/decodeMainnetPhoenixTransaction.ts
@@ -3,7 +3,7 @@ import { Connection } from "@solana/web3.js";
 import * as Phoenix from "../src";
 
 /*
-Prints out the Phoenix events for a specific transaction. Notable, the transaction being parsed in this
+Prints out the Phoenix Legacy events for a specific transaction. Notable, the transaction being parsed in this
 example is a Solana V0 transaction (rather than a legacy Solana transaction)
 
 Expected output:

--- a/typescript/phoenix-sdk/examples/placeLimitOrder.ts
+++ b/typescript/phoenix-sdk/examples/placeLimitOrder.ts
@@ -9,9 +9,9 @@ import { airdropSplTokensForMarketIxs } from "../src/utils/genericTokenMint";
 
 import * as PhoenixSdk from "../src";
 
-// This script sets up a trader as a maker on a phoenix market and sends a limit order on behalf of the trader.
+// This script sets up a trader as a maker on a Phoenix Legacy market and sends a limit order on behalf of the trader.
 // You can execute this Typescript script by using ts-node, the Typescript execution and REPL package for node.js. Installation and details: https://www.npmjs.com/package/ts-node
-// Example: At the root Phoenix SDK directory, run `ts-node typescript/phoenix-sdk/examples/placeLimitOrder.ts`
+// Example: At the root Phoenix Legacy SDK directory, run `ts-node typescript/phoenix-sdk/examples/placeLimitOrder.ts`
 export async function placeLimitOrderExample() {
   const endpoint = "https://api.devnet.solana.com";
   const connection = new Connection(endpoint);

--- a/typescript/phoenix-sdk/examples/seatManager.ts
+++ b/typescript/phoenix-sdk/examples/seatManager.ts
@@ -19,10 +19,10 @@ const devnetSeatManagerAuthority = new PublicKey(
   "AJbjEM3LCmFZq57fKg9Cmz4RaXyZn48H6T5KBwRsvF81"
 );
 
-// This script contains actions that you can perform on a Phoenix Seat account.
+// This script contains actions that you can perform on a Phoenix Legacy Seat account.
 // The main actions are: (i) claim seat, (ii) evict seat, (iii) and get a market's Seat Manager data, each contained in example functions below.
 // You can execute this Typescript script by using ts-node, the Typescript execution and REPL package for node.js. Installation and details: https://www.npmjs.com/package/ts-node
-// Example: At the root Phoenix SDK directory, run `ts-node typescript/phoenix-sdk/examples/seatManager.ts`
+// Example: At the root Phoenix Legacy SDK directory, run `ts-node typescript/phoenix-sdk/examples/seatManager.ts`
 
 // Get the seat manager data for a given market.
 // Useful if you want to know the seat manager authority, the seat manager successor, the number of makers on the market, or designated market makers, if any.
@@ -64,7 +64,7 @@ export async function getSeatManager() {
   );
 }
 
-// You need to claim a seat on a Phoenix market before you can place limit orders.
+// You need to claim a seat on a Phoenix Legacy market before you can place limit orders.
 // This example shows how to claim a seat on a given market.
 // If you are new to a market and want to place a limit order,
 // please see the `getMakerSetupInstructionsForMarket` function and the `placeLimitOrder.ts` in the examples directory, which contains additional logic to place limit orders.

--- a/typescript/phoenix-sdk/examples/simpleMarketMaker.ts
+++ b/typescript/phoenix-sdk/examples/simpleMarketMaker.ts
@@ -9,7 +9,7 @@ import * as PhoenixSdk from "../src";
 import fs from "fs";
 import { airdropSplTokensForMarketIxs } from "../src/utils/genericTokenMint";
 
-// This script runs a simple market maker example, which provides limit order bids and asks, on a devnet phoenix market.
+// This script runs a simple market maker example, which provides limit order bids and asks, on a devnet Phoenix Legacy market.
 // To run: ts-node examples/simpleMarketMaker.ts $PATH-TO-KEYPAIR.
 export async function simpleMarketMaker(privateKeyPath: string) {
   // Devnet test market - SOL/USDC
@@ -30,7 +30,7 @@ export async function simpleMarketMaker(privateKeyPath: string) {
   // Load in the keypair for the trader you wish to trade with
   const privateKey = JSON.parse(fs.readFileSync(privateKeyPath, "utf-8"));
   const trader = Keypair.fromSeed(Uint8Array.from(privateKey.slice(0, 32)));
-  // Create a Phoenix Client
+  // Create a Phoenix Legacy Client
   const client = await PhoenixSdk.Client.create(connection);
   // Get the market metadata for the market you wish to trade on
   const marketState = client.marketStates.get(marketPubkey.toString());

--- a/typescript/phoenix-sdk/package.json
+++ b/typescript/phoenix-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ellipsis-labs/phoenix-sdk",
   "version": "2.0.4",
-  "description": "TypeScript SDK for Phoenix",
+  "description": "TypeScript SDK for Phoenix Legacy",
   "author": "Ellipsis Labs",
   "repository": "https://github.com/Ellipsis-Labs/phoenix-sdk",
   "main": "dist/index.js",

--- a/typescript/phoenix-sdk/psm-src/instructions/ChangeMarketFeeRecipient.ts
+++ b/typescript/phoenix-sdk/psm-src/instructions/ChangeMarketFeeRecipient.ts
@@ -22,8 +22,8 @@ export const ChangeMarketFeeRecipientStruct = new beet.BeetArgsStruct<{
 /**
  * Accounts required by the _ChangeMarketFeeRecipient_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] marketAuthority The market_authority account must sign to change the fee recipient
  * @property [**signer**] seatManagerAuthority The seat manager authority must sign to change the fee recipient

--- a/typescript/phoenix-sdk/psm-src/instructions/ChangeMarketStatus.ts
+++ b/typescript/phoenix-sdk/psm-src/instructions/ChangeMarketStatus.ts
@@ -36,8 +36,8 @@ export const ChangeMarketStatusStruct = new beet.BeetArgsStruct<
 /**
  * Accounts required by the _ChangeMarketStatus_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [_writable_, **signer**] marketAuthority The market_authority account must sign to change market status
  * @property [**signer**] seatManagerAuthority The seat manager account must sign change market status

--- a/typescript/phoenix-sdk/psm-src/instructions/ClaimMarketAuthority.ts
+++ b/typescript/phoenix-sdk/psm-src/instructions/ClaimMarketAuthority.ts
@@ -22,8 +22,8 @@ export const ClaimMarketAuthorityStruct = new beet.BeetArgsStruct<{
 /**
  * Accounts required by the _ClaimMarketAuthority_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [_writable_] seatManager The seat manager account must sign to claim authority
  * @property [_writable_, **signer**] payer Payer account

--- a/typescript/phoenix-sdk/psm-src/instructions/ClaimSeat.ts
+++ b/typescript/phoenix-sdk/psm-src/instructions/ClaimSeat.ts
@@ -19,8 +19,8 @@ export const ClaimSeatStruct = new beet.BeetArgsStruct<{
 /**
  * Accounts required by the _ClaimSeat_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [_writable_] seatManager The seat manager account is the market authority
  * @property [_writable_] seatDepositCollector Collects deposits for claiming new seats and refunds for evicting seats

--- a/typescript/phoenix-sdk/psm-src/instructions/ClaimSeatAuthorized.ts
+++ b/typescript/phoenix-sdk/psm-src/instructions/ClaimSeatAuthorized.ts
@@ -22,8 +22,8 @@ export const ClaimSeatAuthorizedStruct = new beet.BeetArgsStruct<{
 /**
  * Accounts required by the _ClaimSeatAuthorized_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [_writable_] seatManager The seat manager account is the market authority
  * @property [_writable_] seatDepositCollector Collects deposits for claiming new seats and refunds for evicting seats

--- a/typescript/phoenix-sdk/psm-src/instructions/EvictSeat.ts
+++ b/typescript/phoenix-sdk/psm-src/instructions/EvictSeat.ts
@@ -20,8 +20,8 @@ export const EvictSeatStruct = new beet.BeetArgsStruct<{
 /**
  * Accounts required by the _EvictSeat_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [_writable_] seatManager The seat manager account must sign to evict a seat
  * @property [_writable_] seatDepositCollector Collects deposits for claiming new seats and refunds for evicting seats

--- a/typescript/phoenix-sdk/psm-src/instructions/NameMarketAuthoritySuccessor.ts
+++ b/typescript/phoenix-sdk/psm-src/instructions/NameMarketAuthoritySuccessor.ts
@@ -36,8 +36,8 @@ export const NameMarketAuthoritySuccessorStruct = new beet.BeetArgsStruct<
 /**
  * Accounts required by the _NameMarketAuthoritySuccessor_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] marketAuthority The market_authority account must sign to name market successor
  * @property [**signer**] seatManagerAuthority The seat manager authority must sign to name a new market authority successor

--- a/typescript/phoenix-sdk/src/events.ts
+++ b/typescript/phoenix-sdk/src/events.ts
@@ -91,7 +91,7 @@ export function getPhoenixEventsFromLogData(
 }
 
 /**
- * Returns a list of Phoenix events for a given transaction object
+ * Returns a list of Phoenix Legacy events for a given transaction object
  *
  * @param txData The transaction object returned by `getParsedTransaction` of type `ParsedTransactionWithMeta`
  */
@@ -140,7 +140,7 @@ export function getPhoenixEventsFromTransactionData(
 }
 
 /**
- * Returns a list of Phoenix events for a given transaction signature
+ * Returns a list of Phoenix Legacy events for a given transaction signature
  *
  * @param connection The Solana `Connection` object
  * @param signature The signature of the transaction to fetch
@@ -160,7 +160,7 @@ export async function getPhoenixEventsFromTransactionSignature(
 }
 
 /**
- * Returns a list of Phoenix events for a given transaction signature
+ * Returns a list of Phoenix Legacy events for a given transaction signature
  *
  * @param connection The Solana `Connection` object
  * @param signature The signature of the transaction to fetch

--- a/typescript/phoenix-sdk/src/index.ts
+++ b/typescript/phoenix-sdk/src/index.ts
@@ -27,7 +27,7 @@ export const PROGRAM_ADDRESS = "PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY";
 export const PROGRAM_ID = new PublicKey(PROGRAM_ADDRESS);
 
 /**
- * Returns the Phoenix log authority Pubkey
+ * Returns the Phoenix Legacy log authority Pubkey
  */
 export function getLogAuthority(): PublicKey {
   return PublicKey.findProgramAddressSync([Buffer.from("log")], PROGRAM_ID)[0];

--- a/typescript/phoenix-sdk/src/instructions/CancelAllOrders.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelAllOrders.ts
@@ -20,8 +20,8 @@ export const CancelAllOrdersStruct = new beet.BeetArgsStruct<{
 /**
  * Accounts required by the _CancelAllOrders_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account

--- a/typescript/phoenix-sdk/src/instructions/CancelAllOrdersWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelAllOrdersWithFreeFunds.ts
@@ -22,8 +22,8 @@ export const CancelAllOrdersWithFreeFundsStruct = new beet.BeetArgsStruct<{
 /**
  * Accounts required by the _CancelAllOrdersWithFreeFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @category Instructions

--- a/typescript/phoenix-sdk/src/instructions/CancelMultipleOrdersById.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelMultipleOrdersById.ts
@@ -40,8 +40,8 @@ export const CancelMultipleOrdersByIdStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _CancelMultipleOrdersById_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account

--- a/typescript/phoenix-sdk/src/instructions/CancelMultipleOrdersByIdWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelMultipleOrdersByIdWithFreeFunds.ts
@@ -40,8 +40,8 @@ export const CancelMultipleOrdersByIdWithFreeFundsStruct =
 /**
  * Accounts required by the _CancelMultipleOrdersByIdWithFreeFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @category Instructions

--- a/typescript/phoenix-sdk/src/instructions/CancelUpTo.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelUpTo.ts
@@ -40,8 +40,8 @@ export const CancelUpToStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _CancelUpTo_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account

--- a/typescript/phoenix-sdk/src/instructions/CancelUpToWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/CancelUpToWithFreeFunds.ts
@@ -39,8 +39,8 @@ export const CancelUpToWithFreeFundsStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _CancelUpToWithFreeFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @category Instructions

--- a/typescript/phoenix-sdk/src/instructions/DepositFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/DepositFunds.ts
@@ -37,8 +37,8 @@ export const DepositFundsStruct = new beet.BeetArgsStruct<
 /**
  * Accounts required by the _DepositFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [] seat

--- a/typescript/phoenix-sdk/src/instructions/PlaceLimitOrder.ts
+++ b/typescript/phoenix-sdk/src/instructions/PlaceLimitOrder.ts
@@ -37,8 +37,8 @@ export const PlaceLimitOrderStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _PlaceLimitOrder_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [] seat

--- a/typescript/phoenix-sdk/src/instructions/PlaceLimitOrderWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/PlaceLimitOrderWithFreeFunds.ts
@@ -37,8 +37,8 @@ export const PlaceLimitOrderWithFreeFundsStruct =
 /**
  * Accounts required by the _PlaceLimitOrderWithFreeFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [] seat

--- a/typescript/phoenix-sdk/src/instructions/PlaceMultiplePostOnlyOrders.ts
+++ b/typescript/phoenix-sdk/src/instructions/PlaceMultiplePostOnlyOrders.ts
@@ -40,8 +40,8 @@ export const PlaceMultiplePostOnlyOrdersStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _PlaceMultiplePostOnlyOrders_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [] seat

--- a/typescript/phoenix-sdk/src/instructions/PlaceMultiplePostOnlyOrdersWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/PlaceMultiplePostOnlyOrdersWithFreeFunds.ts
@@ -40,8 +40,8 @@ export const PlaceMultiplePostOnlyOrdersWithFreeFundsStruct =
 /**
  * Accounts required by the _PlaceMultiplePostOnlyOrdersWithFreeFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [] seat

--- a/typescript/phoenix-sdk/src/instructions/ReduceOrder.ts
+++ b/typescript/phoenix-sdk/src/instructions/ReduceOrder.ts
@@ -40,8 +40,8 @@ export const ReduceOrderStruct = new beet.BeetArgsStruct<
 /**
  * Accounts required by the _ReduceOrder_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account

--- a/typescript/phoenix-sdk/src/instructions/ReduceOrderWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/ReduceOrderWithFreeFunds.ts
@@ -39,8 +39,8 @@ export const ReduceOrderWithFreeFundsStruct = new beet.BeetArgsStruct<
 /**
  * Accounts required by the _ReduceOrderWithFreeFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [_writable_, **signer**] trader
  * @category Instructions

--- a/typescript/phoenix-sdk/src/instructions/RequestSeat.ts
+++ b/typescript/phoenix-sdk/src/instructions/RequestSeat.ts
@@ -19,8 +19,8 @@ export const RequestSeatStruct = new beet.BeetArgsStruct<{
 /**
  * Accounts required by the _RequestSeat_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [_writable_, **signer**] payer
  * @property [_writable_] seat

--- a/typescript/phoenix-sdk/src/instructions/Swap.ts
+++ b/typescript/phoenix-sdk/src/instructions/Swap.ts
@@ -37,8 +37,8 @@ export const SwapStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _Swap_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account

--- a/typescript/phoenix-sdk/src/instructions/SwapWithFreeFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/SwapWithFreeFunds.ts
@@ -36,8 +36,8 @@ export const SwapWithFreeFundsStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _SwapWithFreeFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [] seat

--- a/typescript/phoenix-sdk/src/instructions/WithdrawFunds.ts
+++ b/typescript/phoenix-sdk/src/instructions/WithdrawFunds.ts
@@ -37,8 +37,8 @@ export const WithdrawFundsStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _WithdrawFunds_ instruction
  *
- * @property [] phoenixProgram Phoenix program
- * @property [] logAuthority Phoenix log authority
+ * @property [] phoenixProgram Phoenix Legacy program
+ * @property [] logAuthority Phoenix Legacy log authority
  * @property [_writable_] market This account holds the market state
  * @property [**signer**] trader
  * @property [_writable_] baseAccount Trader base token account

--- a/typescript/phoenix-sdk/src/utils/market.ts
+++ b/typescript/phoenix-sdk/src/utils/market.ts
@@ -52,7 +52,7 @@ export const DEFAULT_MATCH_LIMIT = 2048;
 export const DEFAULT_SLIPPAGE_PERCENT = 0.005;
 
 /**
- * Find the trader's seat account on Phoenix market.
+ * Find the trader's seat account on Phoenix Legacy market.
  * If the trader does not have a seat account, the PDA seat pubkey will still be returned.
  * In that case, the seat account will need to be initialized with the claim seat instruction.
  * @param marketPubkey The market's address
@@ -578,7 +578,7 @@ function getL3UiOrder(l3Order: L3Order, marketData: MarketData): L3UiOrder {
 }
 
 /**
- * Returns a Phoenix swap transaction
+ * Returns a Phoenix Legacy swap transaction
  *
  * @param market The market object
  * @param trader The `PublicKey` of the trader

--- a/typescript/phoenix-sdk/src/utils/seatManager.ts
+++ b/typescript/phoenix-sdk/src/utils/seatManager.ts
@@ -72,7 +72,7 @@ export function getSeatDepositCollectorAddress(market: PublicKey): PublicKey {
 }
 
 /**
- * Returns an instruction to claim a seat on a market, via the Phoenix Seat Manager
+ * Returns an instruction to claim a seat on a market, via the Phoenix Legacy Seat Manager
  *
  * @param market The market's address
  * @param trader The trader's address
@@ -101,7 +101,7 @@ export function getClaimSeatIx(
 }
 
 /**
- * Returns an instruction to evict a seat on a market, via the Phoenix Seat Manager
+ * Returns an instruction to evict a seat on a market, via the Phoenix Legacy Seat Manager
  * Evict seat is only allowed if the trader state is full for a given market, unless performed by the seat manager authority
  *
  * @param marketState The market object


### PR DESCRIPTION
Update user-facing docs and SDK comments to use the Phoenix Legacy name. This keeps identifiers and package names unchanged while aligning documentation text.